### PR TITLE
Fix: Commented out styles that seem to be for creating stripes in table rows.

### DIFF
--- a/ui/supplemental_ui/css/supplemental.css
+++ b/ui/supplemental_ui/css/supplemental.css
@@ -127,8 +127,12 @@ table tr:nth-child(2n) {
     background-color: var(--ifm-table-stripe-background);
 }
 
+/*
+### I _think_ that I added these styles in order to create stripes in table rows.
+### However, the right way to do this is using AsciiDoc directives.
 :root {
 --ifm-table-stripe-background: var(--ifm-color-emphasis-100);
 --ifm-color-emphasis-100: var(--ifm-color-gray-100);
 --ifm-color-gray-100: #f5f6f7;
 }
+*/


### PR DESCRIPTION
The right way to do this is using AsciiDoc directives.

### Description of the Changes

The styles that are commented out in this PR seem to be there to create stripes in table rows.
It turns out that the right way to do this is using AsciiDoc directives.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [ ] Changes have been done against dev branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


