### PR TITLE
fix: class hash documentation bug fix

### DIFF
--- a/components/StarkNet/modules/architecture_and_concepts/pages/Contracts/contract-hash.adoc
+++ b/components/StarkNet/modules/architecture_and_concepts/pages/Contracts/contract-hash.adoc
@@ -34,7 +34,7 @@ Bytecode:: Represented by an array of field elements.
 The hash of the class is the chain hash, that is, the xref:../Hashing/hash-functions.adoc#pedersen-hash[Pedersen hash], of the above, computed as follows:
 
 . Start with stem:[$h(0,\text{api_version})$].
-. For every line in the above, excluding the first, compute stem:[$h(h(previous\_line), new\_line)$], where the hash of an array is defined as xref:../Hashing/hash-functions.adoc#starknet-keccak[starknet_keccak].
+. For every line in the above, excluding the first, compute stem:[$h(h(previous\_line), new\_line)$], where the hash of an array is defined as xref:../Hashing/hash-functions.adoc#array_hashing[Array Hashing].
 . Let stem:[$c$] denote the cumulative hash that results from applying the above process; the class's hash is then stem:[$h(c, \textrm{number_of_lines})$], where stem:[$\text{number_of_lines}$] is 7.
 
 For more details, see the https://github.com/starkware-libs/cairo-lang/blob/7712b21fc3b1cb02321a58d0c0579f5370147a8b/src/starkware/starknet/core/os/contracts.cairo#L47[Cairo implementation].


### PR DESCRIPTION
### Description of the Changes

In "How the class hash is computed" section of the class hash documentation, the current version of documentation mentions about starknet_keccak but instead it should be Array hashing. This is because the hash of an array is not defined  as the starknet_keccak. Rather, it is defined as Array hashing.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/178)
<!-- Reviewable:end -->
