### PR TITLE
fix: badly formatted mathematical notation in blocks

### DIFF
--- a/components/StarkNet/modules/architecture_and_concepts/pages/Blocks/header.adoc
+++ b/components/StarkNet/modules/architecture_and_concepts/pages/Blocks/header.adoc
@@ -29,7 +29,7 @@ The following fields define the block header:
 
 [NOTE]
 ====
-The commitment fields event_commitment and transaction_commitment are the roots of a height 64 binary Merkle Patricia tree. The leaf at index $i$ corresponds to the hash of the $i'th$ event for event_commitment and $h(transaction \ hash, signature)$ for invoke transaction_commitment. For other types of transactions, the signature is replaced with $h(0,0)$.
+The commitment fields `event_commitment` and `transaction_commitment` are the roots of a height 64 binary Merkle Patricia tree. The leaf at index stem:[$i$] corresponds to the hash of the stem:[$i'th$] event for `event_commitment` and stem:[$h(transaction \ hash, signature)$] for `invoke transaction_commitment`. For other types of transactions, we use stem:[$h(0,0)$].
 ====
 
 [id="block_hash"]

--- a/components/StarkNet/modules/architecture_and_concepts/pages/Blocks/transactions.adoc
+++ b/components/StarkNet/modules/architecture_and_concepts/pages/Blocks/transactions.adoc
@@ -31,7 +31,7 @@ In order to calculate the transaction hash, we first need to obtain the deployed
 [stem]
 ++++
 \begin{aligned}
-\text{deploy_tx_hash} = h( & ``\text{deploy"}, \text{version}, \text{ contract_address}, \text{sn_keccak}(``\text{constructor"}), \\
+\text{deploy_tx_hash} = h( & \text{"deploy"}, \text{version}, \text{ contract_address}, \text{sn_keccak}(\text{"constructor"}), \\
 & h(\text{constructor_calldata}), 0, \text{chain_id})
 \end{aligned}
 ++++
@@ -94,7 +94,7 @@ The invoke transaction hash is calculated as a hash over the given transaction e
 [stem]
 ++++
 \begin{aligned}
-\text{invoke_v1_tx_hash} = h( & ``\text{invoke"}, \text{version}, \text{sender_address}, 0, h(\text{calldata}), \\
+\text{invoke_v1_tx_hash} = h( & \text{"invoke"}, \text{version}, \text{sender_address}, 0, h(\text{calldata}), \\
 & \text{max_fee}, \text{chain_id}, \text{nonce})
 \end{aligned}
 ++++
@@ -113,7 +113,7 @@ The hash of a v0 invoke transaction is computed as follows:
 [stem]
 ++++
 \begin{aligned}
-\text{invoke_v0_tx_hash} = h( & ``\text{invoke"}, \text{version}, \text{contract_address}, \text{entry_point_selector}, \\
+\text{invoke_v0_tx_hash} = h( & \text{"invoke"}, \text{version}, \text{contract_address}, \text{entry_point_selector}, \\
 & h(\text{calldata}), \text{max_fee}, \text{chain_id})
 \end{aligned}
 ++++
@@ -150,7 +150,7 @@ The hash of a v1 declare transaction is computed as follows:
 [stem]
 ++++
 \begin{aligned}
-\text{declare_v1_tx_hash} = h( & ``\text{declare"}, \text{version}, \text{sender_address}, 0, \text{class_hash}, \text{max_fee}, \text{chain_id}, \text{nonce})
+\text{declare_v1_tx_hash} = h( & \text{"declare"}, \text{version}, \text{sender_address}, 0, \text{class_hash}, \text{max_fee}, \text{chain_id}, \text{nonce})
 \end{aligned}
 ++++
 
@@ -169,7 +169,7 @@ The hash of a v0 declare transaction is computed as follows:
 [stem]
 ++++
 \begin{aligned}
-\text{declare_v0_tx_hash} = h( & ``\text{declare"}, \text{version}, \text{sender_address}, 0, 0, \text{max_fee}, \text{chain_id}, \text{class_hash})
+\text{declare_v0_tx_hash} = h( & \text{"declare"}, \text{version}, \text{sender_address}, 0, 0, \text{max_fee}, \text{chain_id}, \text{class_hash})
 \end{aligned}
 ++++
 

--- a/components/StarkNet/modules/architecture_and_concepts/pages/Contracts/contract-hash.adoc
+++ b/components/StarkNet/modules/architecture_and_concepts/pages/Contracts/contract-hash.adoc
@@ -19,14 +19,14 @@ The selector is an identifier through which the function is callable in transact
 Array of https://www.cairo-lang.org/docs/hello_starknet/l1l2.html#receiving-a-message-from-l1[L1 handlers] entry points::
 Array of constructors entry points:: Currently, the compiler allows only one constructor.
 Array of used builtin names:: An ASCII-encode array, ordered by declaration.
-Program hash:: The xref:../Hashing/hash-functions.adoc#starknet-keccak[starknet_keccak], of the class's program. The class's program is the abi and program part of the `.json` file that the StarkNet compiler outputs when you run the following command:
+Program hash:: The xref:../Hashing/hash-functions.adoc#starknet-keccak[starknet_keccak] of the class's program. The class's program is the abi and program part of the `.json` file that the StarkNet compiler outputs when you run the following command:
 +
 [source,shell]
 ----
 $ starknet-compile --no_debug_info
 ----
 +
-The compiler outputs abi, entrypoint selectors and the program. For program hash, starknet_keccak of only abi and program needs to be calculated. To see the exact computation of this field, see https://github.com/starkware-libs/cairo-lang/blob/7712b21fc3b1cb02321a58d0c0579f5370147a8b/src/starkware/starknet/core/os/contract_hash.py#L116[contract_hash.py^].
+The compiler outputs abi, entrypoint selectors and the program. For program hash, `starknet_keccak` of only abi and program needs to be calculated. To see the exact computation of this field, see https://github.com/starkware-libs/cairo-lang/blob/7712b21fc3b1cb02321a58d0c0579f5370147a8b/src/starkware/starknet/core/os/contract_hash.py#L116[contract_hash.py^].
 Bytecode:: Represented by an array of field elements.
 
 == How the class hash is computed


### PR DESCRIPTION
### Description of the Changes

The formatting of the mathematical notations in [Blocks](https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/header/) is broken (image below). Fixed that and some properly placed quotations in [Transaction structure](https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/).

<img width="850" alt="Screenshot 2023-01-17 at 13 50 15" src="https://user-images.githubusercontent.com/23613565/212903455-0775f887-4e9e-4d66-8883-0498b2d39037.png">


### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/244)
<!-- Reviewable:end -->
