### PR TITLE
chore: fix typos

### DIFF
--- a/components/StarkNet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo0.adoc
+++ b/components/StarkNet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo0.adoc
@@ -151,7 +151,7 @@ link:https://github.com/starkware-libs/cairo-lang/blob/2abd303e1808612b724bc1412
 
 
 [id="get_transaction_info"]
-===`get_transaction_info`
+=== `get_transaction_info`
 
 Gets information about the original transaction.
 

--- a/components/StarkNet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo1.adoc
+++ b/components/StarkNet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo1.adoc
@@ -109,7 +109,7 @@ Deploys a new instance of a previously declared class.
 [horizontal,labelwidth=35]
 * A tuple wrapped with `SyscallResult` where:
 ** The first element is the address of the deployed contract (of type `ContractAddress`)
-** The second element is the resoponse array from the contract's constructor (of type `Span::<felt252>`)
+** The second element is the response array from the contract's constructor (of type `Span::<felt252>`)
 
 .Common library
 

--- a/components/StarkNet/modules/architecture_and_concepts/pages/State/starknet-state.adoc
+++ b/components/StarkNet/modules/architecture_and_concepts/pages/State/starknet-state.adoc
@@ -91,7 +91,7 @@ Where:
 
 Cairo 1.0 classes that are part of the commitment are defined with Sierra, an intermediate representation between Cairo 1.0 and Cairo assembly (see xref:architecture_and_concepts:Contracts/cairo-1-and-sierra.adoc[here] for more information).
 However, the prover only deals with Cairo assembly.
-This means that unless we want the compilation from Sierra to Casm to be part of every block in which the class is used, the commitment must have some information about the assoicated Cairo assembly.
+This means that unless we want the compilation from Sierra to Casm to be part of every block in which the class is used, the commitment must have some information about the associated Cairo assembly.
 
 Today, the user signs the `compiled_class_hash` as part of a xref:../Blocks/transactions.adoc#declare_v2[declare v2] transaction. If the transaction was included in a block, then this `compiled_class_hash` becomes part of the commitment.
 In the future, when Sierra&rarr;Casm compilation becomes part of the Starknet OS, this value may be updated via a proof of the Sierra&rarr;Casm compiler execution, showing that compiling the same class with a newer compiler version results in some new compiled class hash.

--- a/components/StarkNet/modules/getting_started/pages/writing_first_contract.adoc
+++ b/components/StarkNet/modules/getting_started/pages/writing_first_contract.adoc
@@ -141,8 +141,7 @@ mod SimpleStorage {
 }
 ----
 
-You can now follow the steps given in the xref:documentation:getting_started:deploying_contracts
-.adoc[Deploying smart contracts] section to compile and deploy the
+You can now follow the steps given in the xref:documentation:getting_started:deploying_contracts.adoc[Deploying smart contracts] section to compile and deploy the
 above contract.
 
 Congratulations on successfully writing and deploying your first Cairo contract!


### PR DESCRIPTION
### Description of the Changes

Small typo fixes after reading the doc.

### PR Preview URL


### Check List

- [ ] Changes have been done against dev branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


