### PR TITLE
Ensuring that "->" does not turn into an arrow in code blocks.

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Cairo_on_Starknet/cairo-1-and-sierra.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Cairo_on_Starknet/cairo-1-and-sierra.adoc
@@ -38,7 +38,7 @@ The method by which Sierra guarantees that user code is always provable is by co
 
 To better understand the considerations that go into designing the Sierra &rarr; Casm compiler, consider the `find_element` function from the common library of Cairo 0:
 
-[source,cairo]
+[source,cairo,subs="quotes"]
 ----
 func find_element{range_check_ptr}(array_ptr: felt*, elm_size, n_elms, key) -> (elm_ptr: felt*) {
     alloc_locals;

--- a/components/Starknet/modules/architecture_and_concepts/pages/Cairo_on_Starknet/contract-syntax.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Cairo_on_Starknet/contract-syntax.adoc
@@ -79,7 +79,7 @@ Gather your contract’s external and view function signatures under a trait ann
 ====
 old::
 +
-[source,rust,subs="verbatim"]
+[source,rust]
 ----
 #[contract]
 mod CounterContract {
@@ -88,7 +88,7 @@ mod CounterContract {
    #[external]
    fn decrease_counter(amount: u128) { ... }
    #[view]
-   fn get_counter() -> u128 { ... }
+   fn get_counter() \-> u128 { ... }
 }
 ----
 
@@ -100,7 +100,7 @@ new::
 trait ICounterContract<TContractState> {
    fn increase_counter(ref self: TContractState, amount: u128);
    fn decrease_counter(ref self: TContractState, amount: u128);
-   fn get_counter(self: @TContractState) -> u128;
+   fn get_counter(self: @TContractState) \-> u128;
 }
 
 #[starknet::contract]

--- a/components/Starknet/modules/architecture_and_concepts/pages/Cairo_on_Starknet/contract-syntax.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Cairo_on_Starknet/contract-syntax.adoc
@@ -79,7 +79,7 @@ Gather your contract’s external and view function signatures under a trait ann
 ====
 old::
 +
-[source,rust]
+[source,rust,subs="verbatim"]
 ----
 #[contract]
 mod CounterContract {

--- a/components/Starknet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo1.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo1.adoc
@@ -11,7 +11,7 @@ accessing the contract's storage, that standalone programs do not require. The S
 
 [source,cairo,subs="+quotes,+macros"]
 ----
-extern fn get_execution_info_syscall() \-> SyscallResult<Box<starknet::info::ExecutionInfo>> implicits(
+extern fn get_execution_info_syscall() -> SyscallResult<Box<starknet::info::ExecutionInfo>> implicits(
     GasBuiltin, System
 ) nopanic;
 ----

--- a/components/Starknet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo1.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo1.adoc
@@ -11,7 +11,7 @@ accessing the contract's storage, that standalone programs do not require. The S
 
 [source,cairo,subs="+quotes,+macros"]
 ----
-extern fn get_execution_info_syscall() -> SyscallResult<Box<starknet::info::ExecutionInfo>> implicits(
+extern fn get_execution_info_syscall() \-> SyscallResult<Box<starknet::info::ExecutionInfo>> implicits(
     GasBuiltin, System
 ) nopanic;
 ----

--- a/components/Starknet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo1.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Contracts/system-calls-cairo1.adoc
@@ -9,7 +9,7 @@ accessing the contract's storage, that standalone programs do not require. The S
 [discrete]
 ==== Syntax
 
-[source,cairo,subs="+quotes,+macros"]
+[source,cairo,subs="verbatim,+quotes,+macros"]
 ----
 extern fn get_execution_info_syscall() -> SyscallResult<Box<starknet::info::ExecutionInfo>> implicits(
     GasBuiltin, System


### PR DESCRIPTION
### Description of the Changes

Preventing `->` from becoming an arrow in code blocks.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-622/documentation/

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/622)
<!-- Reviewable:end -->
