### PR TITLE
fix: version in declare transaction V2 table

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Blocks/transactions.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Blocks/transactions.adoc
@@ -150,7 +150,7 @@ v0 is no longer supported.
 | `signature` | `List<FieldElement>` | Additional information given by the sender, used to validate the transaction.
 | `max_fee` | `FieldElement` | The maximum fee that the sender is willing to pay for the transaction.
 | `nonce` | `FieldElement` | The transaction nonce.
-| `version` | `FieldElement` | The transaction's version. The value is 1. +
+| `version` | `FieldElement` | The transaction's version. The value is 2. +
 When the fields that comprise a transaction change, either with the addition of a new field or the removal of an existing field, then the transaction version increases. Transaction version 0 is deprecated and will be removed in a future version of Starknet.
 |===
 


### PR DESCRIPTION
### Description of the Changes

This PR use the correct version in `declare transaction V2` table.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/659)
<!-- Reviewable:end -->
