### PR TITLE
docs: update validate_and_execute.adoc to match Starknet v.0.12.1

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Account_Abstraction/validate_and_execute.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Account_Abstraction/validate_and_execute.adoc
@@ -51,6 +51,4 @@ In Ethereum, a transaction is necessarily a call to a specific function in a sma
 [id="reverted_transactions"]
 == Reverted transactions
 
-A transaction is considered reverted when the `&lowbar;&lowbar;execute&lowbar;&lowbar;` function failed. Today, reverted transactions are not included in blocks, but in the future, they will be and the sequencer will be eligible to charge a fee for the work done up to the point of failure, similar to Ethereum.
-
-Currently, the sequencer charges only for successful transactions that result from the successful completion of the `&lowbar;&lowbar;execute&lowbar;&lowbar;` function.
+A transaction is considered reverted when the `&lowbar;&lowbar;execute&lowbar;&lowbar;` function failed. A reverted transaction is included in a block and the sequencer is eligible to charge a fee for the work done up to the point of failure, similar to Ethereum.


### PR DESCRIPTION
### Description of the Changes

This is a small PR that updates the [Reverted transactions section](https://docs.starknet.io/documentation/architecture_and_concepts/Account_Abstraction/validate_and_execute/#reverted_transactions) to match the latest v.0.12.1

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/687)
<!-- Reviewable:end -->
