### PR TITLE
fix: typos

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -24,7 +24,7 @@ link:https://redhat-documentation.github.io/modular-docs/[_Red Hat modular docs 
 
 == Style guidance
 
-These _Documentation guidelines_ are primarily concerned with the modular structure and AsciiDoc / Antora requirements for building Starknet documention. For style guidance, use these style guides in the following order:
+These _Documentation guidelines_ are primarily concerned with the modular structure and AsciiDoc / Antora requirements for building Starknet documentation. For style guidance, use these style guides in the following order:
 
 . xref:starknet_docs_style_guide.adoc[_Starknet documentation style guide_] Reference this guide first. It provides guidance that is specific to Starknet documentation.
 . link:https://redhat-documentation.github.io/supplementary-style-guide[_Red Hat supplementary style guide for product documentation_]. This guide overrides certain guidance from the _Google developer documentation style guide_.
@@ -90,7 +90,7 @@ This line will not appear for _Document B_.
 [NOTE]
 ====
 While the `ifdef/endif` blocks have no size limit, do not use them to
-to conditionalize an entire file. If an entire file is specific to a
+conditionalize an entire file. If an entire file is specific to
 only some distributions, specify them in the `nav.adoc`
 file.
 ====
@@ -165,7 +165,7 @@ To include `attributes.adoc` in `audit.adoc`:
 
 == File names
 
-Try to shorten the file name as much as possible _without_ abbreviating important terms that might cause confusion. For example, the `managing-authorization-policies.adoc` file name would be appropriate for an topic entitled _Managing Authorization Policies_.
+Try to shorten the file name as much as possible _without_ abbreviating important terms that might cause confusion. For example, the `managing-authorization-policies.adoc` file name would be appropriate for a topic entitled _Managing Authorization Policies_.
 
 == Directory names
 
@@ -614,7 +614,7 @@ Run the `starknet new_account` command to initialize an account:
 $ starknet new_account --account <account_name>
 ----
 
-The output verifies that a new account was intialized:
+The output verifies that a new account was initialized:
 
 .Example output
 [source,terminal]
@@ -975,4 +975,4 @@ Text for admonition
 ====
 ....
 
-For a list of available admontion types, see link:https://redhat-documentation.github.io/supplementary-style-guide/#admonitions[Admonitions] in the _Red Hat supplementary style guide for product documentation_.
+For a list of available admonition types, see link:https://redhat-documentation.github.io/supplementary-style-guide/#admonitions[Admonitions] in the _Red Hat supplementary style guide for product documentation_.

--- a/ui/preview-src/fee-mechanism.adoc
+++ b/ui/preview-src/fee-mechanism.adoc
@@ -46,7 +46,7 @@ Let's go over a concrete example first. For example, imagine the following trace
 
 The proof will be closed and sent to L1 when any of these components becomes full. It's important to realize that the division to builtins must be predetermined! We can't decide on the fly to have proof with 20,000,001 Pedersen and nothing else.
 
-Suppose, for example, that a transaction uses 10,000 Cairo steps and 500 Pedersen hashes. We can squeeze at most 40,000 such transactions into our hypothetical trace (20,000,000/500). Therefore, its gas price will be correlated with 1/40,000 the cost of submitting proof. Notice we completely ignored the number of Cairo steps this transaction performance estimation, as it is not the limiting factor (since 500,000,000/10,000 > 20,000,000/500). With this example in mind, we can now formulate the exact fee associated with L2 computation.
+Suppose, for example, that a transaction uses 10,000 Cairo steps and 500 Pedersen hashes. We can squeeze at most 40,000 such transactions into our hypothetical trace (20,000,000/500). Therefore, its gas price will be correlated with 1/40,000 the cost of submitting proof. Notice we completely ignored the number of Cairo steps in this transaction performance estimation, as it is not the limiting factor (since 500,000,000/10,000 > 20,000,000/500). With this example in mind, we can now formulate the exact fee associated with L2 computation.
 
 ==== General Case
 
@@ -138,9 +138,9 @@ Consequently, the fee associated with a single l2→l1 message is:
 
 ==== Deployed Contracts
 
-When a transactions which raises the `deploy` syscall is included in a state update, the following xref:../Data_Availability/on-chain-data.adoc#format[data] reaches L1:
+When a transaction which raises the `deploy` syscall is included in a state update, the following xref:../Data_Availability/on-chain-data.adoc#format[data] reaches L1:
 
-* contract addresss
+* contract address
 * class hash
 
 Consequently, the fee associated with a single deployment is:

--- a/ui/preview-src/starknet-events.adoc
+++ b/ui/preview-src/starknet-events.adoc
@@ -45,7 +45,7 @@ assert data[2] = 3
 emit_event(2, keys, 3, data)
 ----
 
-The above code emits an event with two keys, the https://www.cairo-lang.org/docs/how_cairo_works/consts.html#short-string-literals[strings] "status" and "deposit" (think of those as identifiers of the event that can be used for indexing) and three data elments 1, 2, 3.
+The above code emits an event with two keys, the https://www.cairo-lang.org/docs/how_cairo_works/consts.html#short-string-literals[strings] "status" and "deposit" (think of those as identifiers of the event that can be used for indexing) and three data elements 1, 2, 3.
 
 [TIP]
 ====

--- a/ui/preview-src/token-bridge.adoc
+++ b/ui/preview-src/token-bridge.adoc
@@ -22,7 +22,7 @@ The user calls the function `deposit` (see https://github.com/starkware-libs/sta
 * Emits a deposit https://github.com/starkware-libs/starkgate-contracts/blob/28f4032b101003b2c6682d753ea61c86b732012c/src/starkware/starknet/apps/starkgate/solidity/StarknetTokenBridge.sol#L101[event] with the sender address on L1, the recipient address on L2, and the amount
 * Sends a message to the relevant L2 bridge with the amount to be transferred, and the recipient address as parameters. Note that, since every single bridge is dedicated to one token type, the token type doesn't have to be explicit here.
 
-At the end of this step (i.e., after the execution on L1) the deposit transaction is known to StarkNet's sequencer, yet sequencers may wait for enough L1 confirmations before corresponding deposit transaction is initated on L2. During this step, the status of the L2 deposit transaction is xref:../Blocks/transaction-life-cycle.adoc#not_received[`NOT_RECEIVED`].
+At the end of this step (i.e., after the execution on L1) the deposit transaction is known to StarkNet's sequencer, yet sequencers may wait for enough L1 confirmations before corresponding deposit transaction is initiated on L2. During this step, the status of the L2 deposit transaction is xref:../Blocks/transaction-life-cycle.adoc#not_received[`NOT_RECEIVED`].
 
 [id="step_2_deposit_triggered_on_starknet"]
 ==== Step 2: Deposit Triggered on StarkNet
@@ -60,7 +60,7 @@ After the withdraw message has been recorded on the StarkNet Core Contract, anyo
 
 [NOTE]
 ====
-This step is permissionless, and may be performed by anyone. Since the user's address is part of the recorded message on L1, he will be the recepient of the funds, regardless of who called the `withdraw` function on L1.
+This step is permissionless, and may be performed by anyone. Since the user's address is part of the recorded message on L1, he will be the recipient of the funds, regardless of who called the `withdraw` function on L1.
 ====
 
 [id="starkgate_alpha_limitations"]

--- a/ui/preview-src/upcoming_versions.adoc
+++ b/ui/preview-src/upcoming_versions.adoc
@@ -71,7 +71,7 @@ The following is an example of the new version of the `DECLARE` transaction:
 
 Upon receiving a `DECLARE v2` transaction, the sequencer will run `&lowbar;&lowbar;validate&lowbar;declare&lowbar;&lowbar;` (similarly to version 1).
 If the transaction is found valid, the sequencer will compile the contract class to Casm and ensure that the resulting compiled class hash equals the given `compiled_class_hash`.
-If the hashes do not match, the sequencer is elligible to charge a fee for the transaction (this is necessary to prevent a potential DOS on the sequencer).
+If the hashes do not match, the sequencer is eligible to charge a fee for the transaction (this is necessary to prevent a potential DOS on the sequencer).
 If the validation was success and the compilation resulted in a matching compiled class hash, the sequencer proceeds to store the given class in its DB and updates the classes tree with the `(class_hash, compiled_class_hash)` pair.
 
 ### Deploy and library_call


### PR DESCRIPTION
Fix: typos

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/693)
<!-- Reviewable:end -->
