### PR TITLE
fix: removed image from L1-L2 communication

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/L1-L2_Communication/messaging-mechanism.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/L1-L2_Communication/messaging-mechanism.adoc
@@ -27,9 +27,9 @@ Later, the recipient address on L1 can access and consume the message as part of
 
 This is done by calling https://github.com/starkware-libs/cairo-lang/blob/4e233516f52477ad158bc81a86ec2760471c1b65/src/starkware/starknet/eth/StarknetMessaging.sol#L119[`consumeMessageFromL2`] in the Starknet Core Contract, who verifies that the hash corresponds to a stored message and that the caller is indeed the recipient on L1. In such a case, the reference count of the message hash in the Starknet Core Contract decreases by 1.
 
-The above flow is illustrated in the following diagram:
-
-image::l2l1.png[l2l1]
+// The above flow is illustrated in the following diagram:
+// THIS IMAGE IS WRONG & MISLEADING AND THUS COMMENTED OUT UNTIL FIXED
+// image::l2l1.png[l2l1]
 
 [id="structure_and_hashing_l2-l1"]
 === L2 → L1 structure and hashing
@@ -75,9 +75,9 @@ Contracts on L1 can interact asynchronously with contracts on L2 via the L1→L2
 . The state update is received on the Core contract.
 . the message is cleared from the Core contract's storage. At this point, the message is handled.
 
-The above flow is illustrated in the following diagram:
-
-image::l1l2.png[l1l2]
+// The above flow is illustrated in the following diagram:
+// THIS IMAGE IS WRONG & MISLEADING AND THUS COMMENTED OUT UNTIL FIXED
+// image::l1l2.png[l1l2]
 
 An L1→L2 message consists of:
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/L1-L2_Communication/messaging-mechanism.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/L1-L2_Communication/messaging-mechanism.adoc
@@ -27,9 +27,9 @@ Later, the recipient address on L1 can access and consume the message as part of
 
 This is done by calling https://github.com/starkware-libs/cairo-lang/blob/4e233516f52477ad158bc81a86ec2760471c1b65/src/starkware/starknet/eth/StarknetMessaging.sol#L119[`consumeMessageFromL2`] in the Starknet Core Contract, who verifies that the hash corresponds to a stored message and that the caller is indeed the recipient on L1. In such a case, the reference count of the message hash in the Starknet Core Contract decreases by 1.
 
-// The above flow is illustrated in the following diagram:
-// THIS IMAGE IS WRONG & MISLEADING AND THUS COMMENTED OUT UNTIL FIXED
-// image::l2l1.png[l2l1]
+The above flow is illustrated in the following diagram:
+
+image::l2l1.png[l2l1]
 
 [id="structure_and_hashing_l2-l1"]
 === L2 → L1 structure and hashing


### PR DESCRIPTION
### Description of the Changes

Removed image from L1-L2 communication, approved by Shani.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-698/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/698)
<!-- Reviewable:end -->
