### PR TITLE
fix: Remove max_fee from messaging-mechanism.adoc

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/L1-L2_Communication/messaging-mechanism.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/L1-L2_Communication/messaging-mechanism.adoc
@@ -167,7 +167,6 @@ l1_handler_tx_hash = ℎ(
     contract_address,
     entry_point_selector,
     ℎ(calldata),
-    max_fee,
     chain_id,
     nonce
 )


### PR DESCRIPTION
### Description of the Changes

From Oded: We found a mistake in the docs regarding the L1->L2 message hash calculation: max_fee  is not currently part of the hash calculation. Can we please remove it?

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/700)
<!-- Reviewable:end -->
