### PR TITLE
Update transaction-life-cycle.adoc

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transaction-life-cycle.adoc
@@ -15,6 +15,7 @@ A transaction is submitted to one of the gateways, functioning as the Mempool an
 === 2. Validation
 The Mempool performs validation on the transaction to check for its validity. If the transaction is invalid, it will not proceed to the next stages.
 // There is a step missing that the sequencer runs the validation again before _execute_
+
 === 3. Execution
 The sequencer operation sequentially applies the validated transactions to the state. If a transaction fails during execution, it will be included in the block with the status `REVERTED`.
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transaction-life-cycle.adoc
@@ -14,7 +14,7 @@ A transaction is submitted to one of the gateways, functioning as the Mempool an
 
 === 2. Validation
 The Mempool performs validation on the transaction to check for its validity. If the transaction is invalid, it will not proceed to the next stages.
-
+// There is a step missing that the sequencer runs the validation again before _execute_
 === 3. Execution
 The sequencer operation sequentially applies the validated transactions to the state. If a transaction fails during execution, it will be included in the block with the status `REVERTED`.
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transaction-life-cycle.adoc
@@ -14,6 +14,7 @@ A transaction is submitted to one of the gateways, functioning as the Mempool an
 
 === 2. Validation
 The Mempool performs validation on the transaction to check for its validity. If the transaction is invalid, it will not proceed to the next stages.
+
 // There is a step missing that the sequencer runs the validation again before _execute_
 
 === 3. Execution

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transaction-life-cycle.adoc
@@ -13,17 +13,18 @@ The transaction lifecycle in Starknet involves the following high level steps:
 A transaction is submitted to one of the gateways, functioning as the Mempool and marks the transaction status as `RECEIVED`.
 
 === 2. Validation
+
+==== 2.1 Mempool validation
 The Mempool performs validation on the transaction to check for its validity. If the transaction is invalid, it will not proceed to the next stages.
 
-// There is a step missing that the sequencer runs the validation again before _execute_
+==== 2.2 Sequencer validation
+The sequencer performs validation on the transaction prior to execution to ensure that the transaction is still valid. If the transaction is invalid, it will not proceed to the next stages.
 
 === 3. Execution
 The sequencer operation sequentially applies the validated transactions to the state. If a transaction fails during execution, it will be included in the block with the status `REVERTED`.
 
 === 4. Proof Generation
 The Prover stage executes the operating system on the new block, computes the proof, and transmits it to L1.
-
-
 
 [id="transaction_status"]
 


### PR DESCRIPTION
In step 2 we need to write that there are to validation steps, one occurs in the gateways and again in the sequencer. I added this comment:  // There is a step missing that the sequencer runs the validation again before _execute_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/764)
<!-- Reviewable:end -->
