### PR TITLE
Fix order of deploy account hash calculation

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transactions.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/Blocks/transactions.adoc
@@ -317,7 +317,7 @@ deploy_account_tx_hash = ℎ(
     version,
     contract_address,
     0,
-    ℎ(constructor_calldata, class_hash, contract_address_salt),
+    ℎ(class_hash, contract_address_salt, constructor_calldata),
     max_fee,
     chain_id,
     nonce


### PR DESCRIPTION
### Description of the Changes

Fix order of deploy account hash calculation:
ℎ(class_hash, contract_address_salt, constructor_calldata),

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [ ] Changes have been done against dev branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/767)
<!-- Reviewable:end -->
