### PR TITLE
Update documentation version notes 

### DIFF
--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -17,6 +17,7 @@ The current version on each environment are listed within the table below:
 |===
 
 
+[id="version0.12.2"]
 == Starknet v0.12.2 (September 4th 23)
 
 Starknet v0.12.2 is live on Mainnet.
@@ -27,6 +28,7 @@ This version includes the following changes:
 * Resolving Mismatches in Queries: An extension to the `get_state_update` endpoint in the sequencer gateway that returns both the pending state diff and the pending block together.
 * Increased maximum Cairo steps per transaction from 1 million to 3 million.
 
+[id="version0.12.1"]
 == Starknet v0.12.1 (August 21st 23)
 
 Starknet v0.12.1 is live on Mainnet.
@@ -38,19 +40,6 @@ This version includes the following changes:
 * Keccak builtin.
 
 [id="version0.12.0"]
-
-== Starknet v0.12.1 (August 7th, 23)
-
-Starknet v0.12.1 is live on both Testnets.
-
-This version includes the following changes:
-
-* Mempool Validation.
-* Inclusion of Failed Transactions.
-* Keccak builtin.
-
-You can read more about these changes on the xref:starknet_versions:upcoming_versions.adoc[upcoming versions] page.
-
 == Starknet v0.12.0 (July 12th, 23)
 
 Starknet v0.12.0 is live on Mainnet.
@@ -64,7 +53,6 @@ This version contains the following changes:
 * Change HTTP error code from 500 to 400 on API errors.
 
 [id="version0.11.2"]
-
 == Starknet v0.11.2 (May 31, 23)
 
 Starknet v0.11.2 is live on Mainnet.
@@ -74,7 +62,6 @@ This version contains the following changes:
 * Upgrade Cairo 1.0 version to v1.0.0-rc0 (Cairo 1.0 activated on Starknet!)
 
 [id="version0.11.1"]
-
 == Starknet v0.11.1 (May 23, 23)
 
 Starknet v0.11.1 is live on Mainnet.


### PR DESCRIPTION
- Removed Starknet v0.12.1 testnet mention since it's a duplicate of the mainnet and looking at the history, we don't have testnet versions. 
- added ids to each version since it creates a cleaner link

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/794)
<!-- Reviewable:end -->
