### PR TITLE
docs: markdown link of Ethereum account

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Accounts/approach.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Accounts/approach.adoc
@@ -19,7 +19,14 @@ While not mandatory at the protocol level, a richer standard interface for accou
 
 In Starknet, similar to Ethereum, every contract has a nonce. This nonce is sequential; when a transaction is sent from an account, its nonce must match the account's nonce and it's incremented after the transaction is executed (whether or not it was reverted).
 
-Note that, in Starknet, only the nonce of account contracts (that is, those adhering to the above structure) can be non-zero. This differs from Ethereum, where regular smart contracts ( called https://ethereum.org/en/developers/docs/accounts/[_Contract Accounts_, as opposed to _Externally Owned Accounts_] ) can increment their nonce by deploying smart contracts, that is, executing the `CREATE` and `CREATE2` opcodes.
+[NOTE]
+====
+In Starknet, only the nonce of account contracts, that is, those adhering to the above structure, can be non-zero. 
+
+In contrast, in Ethereum, regular smart contracts, known as _Contract Accounts_, as opposed to _Externally Owned Accounts_ can increment their nonce by deploying smart contracts, that is, executing the `CREATE` and `CREATE2` opcodes. 
+
+For more information on accounts in Ethereum, see link:https://ethereum.org/en/developers/docs/accounts/[Ethereum Accounts] in the Ethereum documentation.
+====
 
 A nonce serves two important roles:
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Accounts/approach.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Accounts/approach.adoc
@@ -19,7 +19,7 @@ While not mandatory at the protocol level, a richer standard interface for accou
 
 In Starknet, similar to Ethereum, every contract has a nonce. This nonce is sequential; when a transaction is sent from an account, its nonce must match the account's nonce and it's incremented after the transaction is executed (whether or not it was reverted).
 
-Note that, in Starknet, only the nonce of account contracts (that is, those adhering to the above structure) can be non-zero. This differs from Ethereum, where regular smart contracts ( called https://ethereum.org/en/developers/docs/accounts/["Contract Accounts", as opposed to "Externally Owned Accounts"] ) can increment their nonce by deploying smart contracts, i.e. executing the CREATE and CREATE2 opcodes.
+Note that, in Starknet, only the nonce of account contracts (that is, those adhering to the above structure) can be non-zero. This differs from Ethereum, where regular smart contracts ( called https://ethereum.org/en/developers/docs/accounts/[_Contract Accounts_, as opposed to _Externally Owned Accounts_] ) can increment their nonce by deploying smart contracts, that is, executing the `CREATE` and `CREATE2` opcodes.
 
 A nonce serves two important roles:
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Accounts/approach.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Accounts/approach.adoc
@@ -19,7 +19,7 @@ While not mandatory at the protocol level, a richer standard interface for accou
 
 In Starknet, similar to Ethereum, every contract has a nonce. This nonce is sequential; when a transaction is sent from an account, its nonce must match the account's nonce and it's incremented after the transaction is executed (whether or not it was reverted).
 
-Note that, in Starknet, only the nonce of account contracts (that is, those adhering to the above structure) can be non-zero. This differs from Ethereum, where regular smart contracts (called ["Contract Accounts", as opposed to "Externally Owned Accounts"](https://ethereum.org/en/developers/docs/accounts/) can increment their nonce by deploying smart contracts, i.e. executing the CREATE and CREATE2 opcodes.
+Note that, in Starknet, only the nonce of account contracts (that is, those adhering to the above structure) can be non-zero. This differs from Ethereum, where regular smart contracts ( called https://ethereum.org/en/developers/docs/accounts/["Contract Accounts", as opposed to "Externally Owned Accounts"] ) can increment their nonce by deploying smart contracts, i.e. executing the CREATE and CREATE2 opcodes.
 
 A nonce serves two important roles:
 


### PR DESCRIPTION
### Description of the Changes

Fixed the formatting of the Ethereum account markdown link to ensure it displays correctly in the preview.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/858)
<!-- Reviewable:end -->
