### PR TITLE
chore: Add peer review guidelines to Contribution guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -984,4 +984,13 @@ Text for admonition
 ====
 ....
 
-For a list of available admonition types, see link:https://redhat-documentation.github.io/supplementary-style-guide/#admonitions[Admonitions] in the _Red Hat supplementary style guide for product documentation_.
+For a list of available admonition types, see link:https://redhat-documentation.github.io/supplementary-style-guide/#admonitions[Admonitions] in the _Red Hat supplementary style guide for product documentation.
+
+[#peer_review]
+== Peer reviews
+
+* Easy fixes: For simple fixes such as fixing typos, any writer with merge permissions can go ahead and merge those fixes without any review.
+
+* New features: When documenting new features or significant changes to existing functionality, you must have a peer review prior to merging.
+
+* Outdated content that should be updated as quickly as possible: You should get a peer review, but if the assigned reviewer does not review it within ~48 hours, then you can merge it with technical updates and follow up with the peer review as soon as possible.


### PR DESCRIPTION
### Description of the Changes

doc_guidelines.adoc: Added section on guidelines for getting peer reviews

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [ ] Changes have been done against dev branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/862)
<!-- Reviewable:end -->
