### PR TITLE
Chore: Fix merge instructions in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,16 +120,16 @@ starknet-docs (master) $ git fetch origin
 +
 [source,bash]
 ----
-starknet-docs (master) $ git merge dev
+starknet-docs (master) $ git merge origin/dev
 ----
 
 +
-Your local version of `master` now includes all the changes from `dev`.
+Your local version of `master` now includes all the changes from the remove version of `dev`.
 . Push the local version of `master` to Github:
 +
 [source,bash]
 ----
-starknet-docs (master) $ git push -f origin master
+starknet-docs (master) $ git push origin master
 ----
 +
 Github increments the version numbers in `package.json` and `package-lock.json`, and updates `CHANGELOG.md` with the descriptions of each PR that was just merged into `master`.
@@ -140,5 +140,6 @@ Github increments the version numbers in `package.json` and `package-lock.json`,
 starknet-docs (master) $ git checkout dev
 starknet-docs (dev) $ git fetch origin
 starknet-docs (dev) $ git rebase origin/master
+starknet-docs (dev) $ git push origin dev
 ----
 


### PR DESCRIPTION
### Description of the Changes

Instructions for merging dev to master were incorrect. Need to specify:

`git merge origin/dev`

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/879)
<!-- Reviewable:end -->
