### PR TITLE
Update important_addresses.adoc with Goerli 2 deprecation

### DIFF
--- a/components/Starknet/modules/tools/pages/important_addresses.adoc
+++ b/components/Starknet/modules/tools/pages/important_addresses.adoc
@@ -14,6 +14,10 @@ Verifier address::  link:https://goerli.etherscan.io/address/0x8f97970aC5a9aa8D1
 Sequencer base URL for API routing:: \https://alpha4.starknet.io
 
 == Starknet Alpha version on Goerli testnet 2
+[IMPORTANT]
+====
+Goerli testnet 2 is deprecated and might be introduced with breaking changes without notice.
+====
 
 The Starknet core contract:: link:https://goerli.etherscan.io/address/0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c[`0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c`^]
 Verifier address::  link:https://goerli.etherscan.io/address/0x8f97970aC5a9aa8D130d35146F5b59c4aef57963[`0x8f97970aC5a9aa8D130d35146F5b59c4aef57963`^]


### PR DESCRIPTION
Update docs with a note on Goerli Testnet 2 deprecation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/891)
<!-- Reviewable:end -->
