### PR TITLE
Update version_notes.adoc - remove Goerli testnet 2

### DIFF
--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -13,7 +13,6 @@ Within Starknet's deployment pipeline there are separate and distinct networks t
 |*Environment* |*Starknet version*|*Sierra version*|*Cairo version*
 |Mainnet|0.12.2|1.3.0|2.0.0 - 2.3.0
 |Goerli Testnet 1|0.12.2|1.3.0|2.0.0 - 2.3.0
-|Goerli Testnet 2|0.12.2|1.3.0|2.0.0 - 2.3.0
 |===
 
 


### PR DESCRIPTION
Goerli testnet 2 is deprecated and, therefore, removed from the docs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/904)
<!-- Reviewable:end -->
