### PR TITLE
fix: Removed collabsible section for `get_execution_info`

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/system-calls-cairo1.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/system-calls-cairo1.adoc
@@ -35,9 +35,6 @@ If `block_number` is less than the first block number of v0.12.0, the function r
 [id="get_execution_info"]
 == `get_execution_info`
 
-[%collapsible]
-====
-
 [discrete]
 ==== Syntax
 
@@ -69,7 +66,7 @@ None.
 ==== Common library
 
 link:https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L35[`syscalls.cairo`^]
-====
+
 
 [id="call_contract"]
 == `call_contract`


### PR DESCRIPTION
### Description of the Changes

Removed collabsible section for `get_execution_info`

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-908/documentation/architecture_and_concepts/Smart_Contracts/system-calls-cairo1/

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/908)
<!-- Reviewable:end -->
