### PR TITLE
docs: Removed Goerli testnet 2

### DIFF
--- a/components/Starknet/modules/ROOT/partials/snippet_important_goerli2_removed.adoc
+++ b/components/Starknet/modules/ROOT/partials/snippet_important_goerli2_removed.adoc
@@ -1,4 +1,4 @@
 [IMPORTANT]
 ====
-Goerli testnet 2 is removed. Use Goerli testnet 1.
+Goerli testnet 2 is removed. Use Goerli testnet.
 ====

--- a/components/Starknet/modules/ROOT/partials/snippet_important_goerli2_removed.adoc
+++ b/components/Starknet/modules/ROOT/partials/snippet_important_goerli2_removed.adoc
@@ -1,0 +1,4 @@
+[IMPORTANT]
+====
+Goerli testnet 2 is removed. Use Goerli testnet 1.
+====

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
@@ -346,3 +346,5 @@ The following constants are currently used:
 
 * `SN_MAIN` for Starknet's main network.
 * `SN_GOERLI` for Starknet's public testnet.
+
+include::ROOT:partial$snippet_important_goerli2_removed.adoc[]

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
@@ -342,8 +342,7 @@ Starknet currently supports three chain IDs. Chain IDs are given as numbers, rep
 ----
 chain_id = int.from_bytes(value, byteorder="big", signed=False)
 ----
-Three constants are currently used:
+The following constants are currently used:
 
 * `SN_MAIN` for Starknet's main network.
 * `SN_GOERLI` for Starknet's public testnet.
-* `SN_GOERLI2` for Starknet developers.

--- a/components/Starknet/modules/starknet_versions/pages/deprecated.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/deprecated.adoc
@@ -1,7 +1,6 @@
 [id="eol"]
 = Deprecated and removed features
 
-
 The following features have been deprecated or removed from Starknet in recent releases.
 
 [cols="1,3"]
@@ -30,6 +29,9 @@ Support for Starknet CLI will be removed in Starknet v0.13.0.
 [cols="1,3"]
 |===
 |Name|Description
+
+| Goerli testnet 2 | Goerli testnet 2 is removed. Use Goerli testnet 1.
+
 |Free L1-> L2 messaging |Previously, sending a message from L1 to L2 had an optional fee associated.
 
 From xref:starknet_versions:version_notes.adoc#version0.11.0[Starknet v0.11.0], the fee mechanism is enforced and the ability to send L1->L2 messages without the corresponding L2 fee has been removed.

--- a/components/Starknet/modules/starknet_versions/pages/deprecated.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/deprecated.adoc
@@ -30,7 +30,7 @@ Support for Starknet CLI will be removed in Starknet v0.13.0.
 |===
 |Name|Description
 
-| Goerli testnet 2 | Goerli testnet 2 is removed. Use Goerli testnet 1.
+| Goerli testnet 2 | Goerli testnet 2 is removed. Use Goerli testnet.
 
 |Free L1-> L2 messaging |Previously, sending a message from L1 to L2 had an optional fee associated.
 

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -16,7 +16,7 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 |Environment |Starknet version|Sierra version|Cairo version
 
 |Mainnet|0.12.2|1.3.0|2.0.0 - 2.3.0
-|Goerli Testnet 1|0.12.2|1.3.0|2.0.0 - 2.3.0
+|Goerli Testnet|0.12.2|1.3.0|2.0.0 - 2.3.0
 |===
 
 

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -13,7 +13,6 @@ Within Starknet's deployment pipeline there are separate and distinct networks t
 |*Environment* |*Starknet version*|*Sierra version*|*Cairo version*
 |Mainnet|0.12.2|1.3.0|2.0.0 - 2.3.0
 |Goerli Testnet 1|0.12.2|1.3.0|2.0.0 - 2.3.0
-|Goerli Testnet 2|0.12.2|1.3.0|2.0.0 - 2.3.0
 |===
 
 

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -7,10 +7,14 @@ The following release notes cover the ongoing version changes to Starknet. To ge
 
 Within Starknet's deployment pipeline there are separate and distinct networks that operate independently of each other for testing before deployment.
 
+
+include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
+
 .Current versions supported in each environment
 [%autowidth.stretch]
 |===
-|*Environment* |*Starknet version*|*Sierra version*|*Cairo version*
+|Environment |Starknet version|Sierra version|Cairo version
+
 |Mainnet|0.12.2|1.3.0|2.0.0 - 2.3.0
 |Goerli Testnet 1|0.12.2|1.3.0|2.0.0 - 2.3.0
 |===

--- a/components/Starknet/modules/tools/pages/important_addresses.adoc
+++ b/components/Starknet/modules/tools/pages/important_addresses.adoc
@@ -1,6 +1,11 @@
 [id="important_addresses"]
 = Important addresses
 
+[IMPORTANT]
+====
+Goerli testnet 2 is removed.
+====
+
 ==  Starknet Alpha on Mainnet
 
 The Starknet core contract:: link:https://etherscan.io/address/0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4[`0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4`^]
@@ -13,26 +18,16 @@ The Starknet core contract:: link:https://goerli.etherscan.io/address/0xde29d060
 Verifier address::  link:https://goerli.etherscan.io/address/0x8f97970aC5a9aa8D130d35146F5b59c4aef57963[`0x8f97970aC5a9aa8D130d35146F5b59c4aef57963`^]
 Sequencer base URL for API routing:: \https://alpha4.starknet.io
 
-== Starknet Alpha version on Goerli testnet 2
-[IMPORTANT]
-====
-Goerli testnet 2 is deprecated and might be introduced with breaking changes without notice.
-====
-
-The Starknet core contract:: link:https://goerli.etherscan.io/address/0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c[`0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c`^]
-Verifier address::  link:https://goerli.etherscan.io/address/0x8f97970aC5a9aa8D130d35146F5b59c4aef57963[`0x8f97970aC5a9aa8D130d35146F5b59c4aef57963`^]
-Sequencer base URL for API routing:: \https://alpha4-2.starknet.io
-
 == Bridged tokens
 
 The tokens that are currently bridged to Starknet are listed in the following `.json` files:
 
 link:https://github.com/starknet-community-libs/starknet-addresses/blob/master/bridged_tokens/mainnet.json[`mainnet.json`^]:: The addresses of the tokens currently bridged to Starknet Mainnet.
 https://github.com/starknet-community-libs/starknet-addresses/blob/master/bridged_tokens/goerli.json[`goerli.json`^]:: The addresses of the tokens currently bridged to Starknet testnet.
-https://github.com/starknet-community-libs/starknet-addresses/blob/master/bridged_tokens/goerli2.json[`goerli2.json`^]:: The addresses of the tokens currently bridged to Starknet testnet2.
 
 Each token has the following parameters:
 
+[horizontal, labelwidth="25"]
 Name:: Token name.
 Symbol:: Token symbol.
 Decimals:: Number of decimal places used to get the user representation.

--- a/components/Starknet/modules/tools/pages/important_addresses.adoc
+++ b/components/Starknet/modules/tools/pages/important_addresses.adoc
@@ -1,10 +1,7 @@
 [id="important_addresses"]
 = Important addresses
 
-[IMPORTANT]
-====
-Goerli testnet 2 is removed.
-====
+include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 
 ==  Starknet Alpha on Mainnet
 


### PR DESCRIPTION
### Description of the Changes

Goerli 2 is no longer supported. This PR removes all mention of Goerli 2, except for one admonition announcing it has been removed.

### PR Preview URL

[Important addresses](https://starknet-io.github.io/starknet-docs/pr-919/documentation/tools/important_addresses/)
[Transaction types>ChainID](https://starknet-io.github.io/starknet-docs/pr-919/documentation/architecture_and_concepts/Network_Architecture/transactions/#chain-id)
[Starknet environments](https://starknet-io.github.io/starknet-docs/pr-919/documentation/starknet_versions/version_notes/#starknet_environments)

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/919)
<!-- Reviewable:end -->
