### PR TITLE
docs: Add limitations to __validate__ function

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Accounts/validate_and_execute.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Accounts/validate_and_execute.adoc
@@ -27,6 +27,11 @@ When the `&lowbar;&lowbar;validate&lowbar;&lowbar;` function fails, no fee will 
 [id="validate_limitations"]
 == Validate limitations
 
+* You can't call functions in external contracts, only in your accoutn contract
+* 1 million Cairo steps (add xref to see Limits and triggers page)
+* see https://github.com/starkware-libs/cairo-lang/releases/tag/v0.12.3 for new 0.12.3 limitations
+* Ask Yoni Ilux for more info.
+
 There are some limitations set on the `&lowbar;&lowbar;validate&lowbar;&lowbar;` function. The purpose of these limitations is twofold:
 
 *   We want to avoid the sequencer having to do a lot of work only to discover that the validation failed and the sequencer is then not eligible to charge a fee (if this was possible, the sequencer would be completely exposed to DOS attacks). Validation, while now abstract and in control of the account owner rather than the protocol, should still be a simple operation. This is why in the future, Starknet will place max steps limitation upon the `&lowbar;&lowbar;validate&lowbar;&lowbar;` function.


### PR DESCRIPTION
### Description of the Changes

Add limitations to __validate__ function

Currently the section [Validate limitations](https://doc.starknet-io/documentation/architecture_and_concepts/Accounts/validate_and_execute/#validate_limitations) doesn't actually list the limitations. This PR fixes that.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [ ] Changes have been done against dev branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


