### PR TITLE
Fix issue #883: Contract storage page is still referring to the old cairo syntax #883

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-storage.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-storage.adoc
@@ -58,6 +58,7 @@ In the following example we define a storage variables with complex values.
 
 [source,js]
 ----
+#[storage]
 struct Storage {
     name: felt252,
     symbol: felt252,

--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-syntax.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-syntax.adoc
@@ -42,6 +42,7 @@ old::
 +
 [source,rust]
 ----
+#[storage]
 struct Storage {
     counter: u128,
     other_contract: IOtherContractDispatcher


### PR DESCRIPTION
### Description of the Changes

Applied new cairo syntax for Contract storage and Contract syntax (maybe someone missed these places)

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [ ] Changes have been done against dev branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


