### PR TITLE
chore: remove dev branch from workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Paste here the specific URL(s) of the content that this PR addresses.
 
 ### Check List
 
-- [ ] Changes have been done against dev branch, and PR does not conflict
+- [ ] Changes have been done against master branch, and PR does not conflict
 - [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`
 
 

--- a/.github/workflows/algolia-indexing.yml
+++ b/.github/workflows/algolia-indexing.yml
@@ -8,7 +8,7 @@ on:
       - "js/algolia-index.js"
       - "components/**/*.adoc"
     branches:
-      - dev
+#      - dev
       - master
 jobs:
   upload_data:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,7 +3,7 @@ name: Push workflow
 on:
   push:
     branches:
-      - dev
+#      - dev
       - master
 
 jobs:

--- a/playbook.yml
+++ b/playbook.yml
@@ -11,7 +11,7 @@ content:
   sources:
     - url: .
       branches: HEAD
-      edit_url: 'https://github.com/starknet-io/starknet-docs/edit/dev/{path}'
+      edit_url: 'https://github.com/starknet-io/starknet-docs/edit/master/{path}'
       start_paths:
         - components/Starknet
     - url: https://github.com/starknet-io/docs-common-content.git


### PR DESCRIPTION
### Description of the Changes

This PR removed the `dev` branch from the workflows.

Using a `dev` branch is a normal part of a source code repo, but the docs flow does not require this branch, and it adds an unnecessary step in the release and publishing flow.

The projected plan is to remove dev and merge branches directly to master (which is planned to change to main in the future, consistent with other repos). In a case where a PR should not be published immediately, such as a feature that is not yet released, a release branch is created to hold that content until the official release date. For example, #933.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/961)
<!-- Reviewable:end -->
