### PR TITLE
feat: Add Starknet version to UI header

### DIFF
--- a/components/Starknet/modules/ROOT/partials/attributes.adoc
+++ b/components/Starknet/modules/ROOT/partials/attributes.adoc
@@ -1,3 +1,0 @@
-:starknet_testnet_version: Sepolia: 0.12.3 | Goerli: 0.12.3
-:starknet_mainnet_version: Mainnet: 0.12.2
-:starknet_version_header: {starknet_mainnet_version} | {starknet_testnet_version}

--- a/components/Starknet/modules/ROOT/partials/attributes.adoc
+++ b/components/Starknet/modules/ROOT/partials/attributes.adoc
@@ -1,0 +1,3 @@
+:starknet_testnet_version: Sepolia: 0.12.3 | Goerli: 0.12.3
+:starknet_mainnet_version: Mainnet: 0.12.2
+:starknet_version_header: {starknet_mainnet_version} | {starknet_testnet_version}

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,7 +20,8 @@ content:
 
 ui:
   bundle:
-    url: https://github.com/starknet-io/starknet-docs-antora-ui/raw/HEAD/build/ui-bundle.zip
+    url: https://github.com/starknet-io/starknet-docs-antora-ui/raw/add_version_header/build/ui-bundle.zip
+#    url: https://github.com/starknet-io/starknet-docs-antora-ui/raw/HEAD/build/ui-bundle.zip
     #    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
     #    url: ./ui/ui-bundle.zip
     snapshot: true
@@ -37,6 +38,12 @@ asciidoc:
     stem: 'latexmath'
     page-pagination: ''
     experimental: ''
+    # These attributes define the version footer, located in the starknet-docs-antora-ui project,
+    # In /src/partials/, in the files footer-content.hbs and starknet_version.hbs.
+    starknet_mainnet_version: 'Mainnet: 0.12.2'
+    starknet_testnet_version: 'Sepolia testnet: 0.12.3 | Goerli testnet: 0.12.3'
+    page-starknet_version: '{starknet_mainnet_version} | {starknet_testnet_version}'
+
 
 antora:
   extensions:

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,8 +20,7 @@ content:
 
 ui:
   bundle:
-    url: https://github.com/starknet-io/starknet-docs-antora-ui/raw/add_version_header/build/ui-bundle.zip
-#    url: https://github.com/starknet-io/starknet-docs-antora-ui/raw/HEAD/build/ui-bundle.zip
+    url: https://github.com/starknet-io/starknet-docs-antora-ui/raw/HEAD/build/ui-bundle.zip
     #    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
     #    url: ./ui/ui-bundle.zip
     snapshot: true


### PR DESCRIPTION
### Description of the Changes

This, together with https://github.com/starknet-io/starknet-docs-antora-ui/pull/28, add a header with Starknet version info on the various testnets and Mainnet.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/976)
<!-- Reviewable:end -->
