### PR TITLE
chore: Delete previews upon merging to master

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,11 @@
 name: Pull request workflow
 
-on: pull_request
+on:
+  pull_request
+
+  push:
+    branches:
+      - master
 
 jobs:
 
@@ -89,3 +94,26 @@ jobs:
         env:
           # USER_TOKEN: "${{ secrets.USER_TOKEN }}"
           GH_TOKEN: "${{ github.token }}"
+
+
+  delete-site-preview:
+    name: Delete Site Preview
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Identify and remove preview build directory
+        run: |
+          #          PR_ID=pr-${{ github.event.after }}
+               PR_ID=pr-${{ github.event.pull_request.number }}
+               PREVIEW_PATH=previews/${PR_ID}
+               if [ -d $PREVIEW_PATH ]; then
+               rm -rf $PREVIEW_PATH
+               git add .
+               git commit -m "Delete preview build for PR $PR_ID after merging to master"
+               git push origin gh-pages
+               fi
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Description of the Changes

Added a workflow to delete old previews upon merging to master.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against master branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/977)
<!-- Reviewable:end -->
