### PR TITLE
Update transactions.adoc with deploy account tx v3 hash calculation

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
@@ -360,7 +360,7 @@ The hash of a `DEPLOY_ACCOUNT` transaction is computed as follows:
 deploy_account_v3_tx_hash = _h_(
     "deploy_account",
     version,
-    sender_address,
+    contract_address,
     _h_(tip, l1_gas_bounds, l2_gas_bounds),
     _h_(paymaster_data),
     chain_id,
@@ -377,6 +377,7 @@ Where:
 * `deploy_account` is a constant prefix string, encoded in ASCII.
 include::partial$snippet_transaction_params.adoc[]
 * `class_hash` is the hash of the xref:architecture_and_concepts:Smart_Contracts/contract-classes.adoc[contract class]. See xref:architecture_and_concepts:Smart_Contracts/class-hash.adoc[Class Hash] for details about how the hash is computed.
+* `contract_address` is calculated as described xref:architecture_and_concepts:Smart_Contracts/contract-address.adoc[here].
 
 === v1 (deprecated) transaction fields
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
@@ -377,7 +377,7 @@ Where:
 * `deploy_account` is a constant prefix string, encoded in ASCII.
 include::partial$snippet_transaction_params.adoc[]
 * `class_hash` is the hash of the xref:architecture_and_concepts:Smart_Contracts/contract-classes.adoc[contract class]. See xref:architecture_and_concepts:Smart_Contracts/class-hash.adoc[Class Hash] for details about how the hash is computed.
-* `contract_address` is calculated as described xref:architecture_and_concepts:Smart_Contracts/contract-address.adoc[here].
+* `contract_address` is the address of the newly deployed account. For information on how this address is calculated, see xref:architecture_and_concepts:Smart_Contracts/contract-address.adoc[Contract address].
 
 === v1 (deprecated) transaction fields
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-address.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-address.adoc
@@ -11,9 +11,9 @@ The contract address is a unique identifier of the contract on Starknet. It is a
 
 The address is computed as follows:
 
-[source,js]
+[source,]
 ----
-contract_address := pedersen(
+contract_address = pedersen(
     “STARKNET_CONTRACT_ADDRESS”,
     deployer_address,
     salt,
@@ -29,6 +29,5 @@ It also thwarts replay attacks by influencing the transaction hash with a unique
 ====
 
 .Additional resources
-* For more information on the address computation, see the https://github.com/starkware-libs/cairo/blob/2c96b181a6debe9a564b51dbeaaf48fa75808d53/corelib/src/starknet/contract_address.cairo[contract_address.cairo] in the Cairo code repository.
 
-
+* For more information on the address computation, see https://github.com/starkware-libs/cairo/blob/2c96b181a6debe9a564b51dbeaaf48fa75808d53/corelib/src/starknet/contract_address.cairo[contract_address.cairo] in the Cairo code repository.


### PR DESCRIPTION
### Description of the Changes

A `deploy_account` tx v3 has a `contract_address` field, and not `sender_address`.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against master branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1012)
<!-- Reviewable:end -->
