### PR TITLE
Update transaction-life-cycle.adoc

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -47,7 +47,10 @@ The following are the possible statuses of a transaction from the moment a user 
 |`SUCCEEDED` |The transaction was successfully executed by the sequencer. It is included in the block.
 |===
 
-Note that if the finality status of a transaction is `RECEIVED` or `REJECTED`, then it will not have an execution status.
+[NOTE]
+====
+If the finality status of a transaction is `RECEIVED` or `REJECTED`, the transaction does not have an execution status.
+====
 
 [id="transaction-state-implications"]
 == State implications of a reverted transaction

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -47,6 +47,7 @@ The following are the possible statuses of a transaction from the moment a user 
 |`SUCCEEDED` |The transaction was successfully executed by the sequencer. It is included in the block.
 |===
 
+Note that if the finality status of a transaction is `RECEIVED` or `REJECTED`, then it will not have an execution status.
 
 [id="transaction-state-implications"]
 == State implications of a reverted transaction


### PR DESCRIPTION
Clarifying sentence of the execution status of a transaction when its finality status is `RECEIVED` or `REJECTED`.

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1032/documentation/architecture_and_concepts/Network_Architecture/transaction-life-cycle/

### Check List

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1032)
<!-- Reviewable:end -->
