### PR TITLE
chore: Add .gitattributes file to enable linguist to identify that AsciiDoc and .yml are used in this repo.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# linguist override file
+# Github uses linguist to detect the languages used in a repo for statistical purposes and to show on the repo's home page.
+# OnlyDust links to this info for the project's stats.
+# This file should make AsciiDoc visible to linguist, so that ultimately OnlyDust will show it.
+# List of supported languages includes AsciiDoc: https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml
+# See: https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#detectable
+#
+
+# Detect .adoc and .yml files
+*.adoc linguist-detectable
+*.yml linguist-detectable
+


### PR DESCRIPTION
### Description of the Changes

Github uses linguist to detect the languages used in a repo for statistical purposes and to show on the repo's home page.
OnlyDust links to this info for the project's stats.

This file should make AsciiDoc visible to linguist, so that ultimately OnlyDust will show it.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against master branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1053)
<!-- Reviewable:end -->
