### PR TITLE
fix: Update tab labels of examples from Cairo v1 to Cairo v2

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/nav.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/nav.adoc
@@ -29,7 +29,7 @@
 *** xref:Smart_Contracts/contract-storage.adoc[Contract storage]
 *** xref:Smart_Contracts/contract-abi.adoc[Contract ABI]
 *** xref:Smart_Contracts/starknet-events.adoc[Events]
-*** xref:Smart_Contracts/contract-syntax.adoc[Migrating a contract from Cairo 0 to Cairo]
+*** xref:Smart_Contracts/contract-syntax.adoc[Migrating a contract from Cairo v1 to Cairo v2]
 *** xref:Smart_Contracts/cairo-and-sierra.adoc[Cairo and Sierra]
 *** xref:Smart_Contracts/system-calls-cairo1.adoc[System calls]
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-syntax.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-syntax.adoc
@@ -1,4 +1,4 @@
-= Migrating a contract from Cairo 0 to Cairo
+= Migrating a contract from Cairo v1 to Cairo v2
 
 With the link:https://github.com/starkware-libs/cairo/releases/tag/v2.0.0-rc0[v2.0.0 release] of the Cairo compiler, the Starknet contract syntax has evolved, affecting the organization of functions, storage, and events.
 
@@ -6,7 +6,7 @@ For more information on the latest syntax changes, see the Community Forum post 
 
 .Prerequisites
 
-* A contract written with the Cairo compiler v1.1.0
+* A contract written with the Cairo compiler v1
 * The most recent version of the Cairo compiler
 
 .Procedure
@@ -15,18 +15,18 @@ For more information on the latest syntax changes, see the Community Forum post 
 +
 [tabs]
 ====
-old::
+Cairo v1::
 +
-[source,rust]
+[source,cairo]
 ----
 #[contract]
 mod CounterContract {
    ...
 }
 ----
-new::
+Cairo v2::
 +
-[source,rust]
+[source,cairo]
 ----
 #[starknet::contract]
 mod CounterContract {
@@ -38,18 +38,18 @@ mod CounterContract {
 +
 [tabs]
 ====
-old::
+Cairo v1::
 +
-[source,rust]
+[source,cairo]
 ----
 struct Storage {
     counter: u128,
     other_contract: IOtherContractDispatcher
 }
 ----
-new::
+Cairo v2::
 +
-[source,rust]
+[source,cairo]
 ----
 #[storage]
 struct Storage {
@@ -72,9 +72,9 @@ For example:
 +
 [tabs]
 ====
-old::
+Cairo v1::
 +
-[source,rust]
+[source,cairo]
 ----
 #[contract]
 mod CounterContract {
@@ -86,9 +86,9 @@ mod CounterContract {
    fn get_counter() -> u128 { ... }
 }
 ----
-new::
+Cairo v2::
 +
-[source,rust]
+[source,cairo]
 ----
 #[starknet::interface]
 trait ICounterContract<TContractState> {
@@ -110,9 +110,9 @@ For example:
 +
 [tabs]
 ====
-old::
+Cairo v1::
 +
-[source,rust]
+[source,cairo]
 ----
 #[contract]
 mod CounterContract {
@@ -124,9 +124,9 @@ mod CounterContract {
    fn get_counter() -> u128 { ... }
 }
 ----
-new::
+Cairo v2::
 +
-[source,rust]
+[source,cairo]
 ----
 #[starknet::interface]
 trait ICounterContract<TContractState> {
@@ -159,18 +159,18 @@ For example:
 +
 [tabs]
 ====
-old::
+Cairo v1::
 +
-[source,rust]
+[source,cairo]
 ----
 #[abi]
 trait IOtherContract {
     fn decrease_allowed() -> bool;
 }
 ----
-new::
+Cairo v2::
 +
-[source,rust]
+[source,cairo]
 ----
 #[starknet::interface]
 trait IOtherContract<TContractState> {
@@ -191,15 +191,15 @@ For example:
 +
 [tabs]
 ====
-old::
+Cairo v1::
 +
-[source,rust]
+[source,cairo]
 ----
 let current = counter::read();
 ----
-new::
+Cairo v2::
 +
-[source,rust]
+[source,cairo]
 ----
 let current = self.counter.read();
 ----
@@ -218,18 +218,18 @@ For example:
 +
 [tabs]
 ====
-old::
+Cairo v1::
 +
-[source,rust]
+[source,cairo]
 ----
 #[event]
 fn counter_increased(amount: u128) {}
 #[event]
 fn counter_decreased(amount: u128) {}
 ----
-new::
+Cairo v2::
 +
-[source,rust]
+[source,cairo]
 ----
 #[event]
 #[derive(Drop, starknet::Event)]
@@ -252,18 +252,18 @@ struct CounterDecreased {
 +
 [tabs]
 ====
-old::
+Cairo v1::
 +
-[source,rust]
+[source,cairo]
 ----
 fn increase_counter(amount: u128) {
     ...
     counter_increased(amount);
 }
 ----
-new::
+Cairo v2::
 +
-[source,rust]
+[source,cairo]
 ----
 fn increase_counter(ref self: ContractState, amount: u128) {
     ...


### PR DESCRIPTION
### Description of the Changes

Updated tabbed examples to Cairo v1/Cairo v2

### PR Preview URL

[Migrating a contract from Cairo v1 to Cairo v2](https://starknet-io.github.io/starknet-docs/pr-1072/documentation/architecture_and_concepts/Smart_Contracts/contract-syntax/)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1072)
<!-- Reviewable:end -->
