### PR TITLE
Docs: Add OtterSec and Beosin to audit providers

### DIFF
--- a/components/Starknet/modules/tools/pages/audit.adoc
+++ b/components/Starknet/modules/tools/pages/audit.adoc
@@ -13,11 +13,13 @@ contracts.
 | Company name | URL
 
 |ABDK | link:https://www.abdk.consulting/[www.abdk.consulting^]
+|Beosin | link:https://beosin.com/[beosin.com^]
 |Chain Security | link:https://chainsecurity.com/[chainsecurity.com^]
 |Consensys Diligence | link:https://consensys.net/diligence/[consensys.net/diligence^]
 |Extropy | link:https://security.extropy.io/[security.extropy.io^]
 |Nethermind | link:https://nethermind.io/[nethermind.io^]
 |Open Zeppelin | link:https://www.openzeppelin.com/[www.openzeppelin.com^]
+|OtterSec | link:https://osec.io/[osec.io^]
 |PeckShield | link:https://peckshield.com/[peckshield.com^]
 |Trail of Bits | link:https://www.trailofbits.com/[www.trailofbits.com^]
 |Zellic | link:https://www.zellic.io[www.zellic.io^]


### PR DESCRIPTION
### Description of the Changes

This PR adds OtterSec and Beosin to the Audit providers page. These two Companies are already added on the starknet.io official website.


### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1075)
<!-- Reviewable:end -->
