### PR TITLE
fix: changed link to example contract

### DIFF
--- a/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
+++ b/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
@@ -23,7 +23,7 @@ Deploying a smart contract in Starknet requires two steps:
 
 [TIP]
 ====
-If you require an example smart contract to test with, you can use a pre prepared example from the Starknet Book link:https://github.com/starknet-edu/starknetbook/blob/main/chapters/book/modules/chapter_1/pages/contracts/src/lib.cairo[here].
+If you require an example smart contract to test with, you can use a pre prepared example from the Starknet Book link:https://github.com/starknet-edu/starknetbook/blob/main/examples/vote-contracts/src/lib.cairo[here].
 ====
 
 == Compiling a smart contract


### PR DESCRIPTION
### Updated broken link to example contracts folder

The link to example contract was broken - here is the old link (https://github.com/starknet-edu/starknetbook/blob/main/chapters/book/modules/chapter_1/pages/contracts/src/lib.cairo)

I have Updated it to examples folder (https://github.com/starknet-edu/starknetbook/blob/main/chapters/book/modules/chapter_1/pages/contracts/src/lib.cairo).

### PR Preview URL



### Check List

- [ ] Changes have been done against main branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1076)
<!-- Reviewable:end -->
