### PR TITLE
fix: Update declare_a_smart_contract.adoc

### DIFF
--- a/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
+++ b/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
@@ -23,7 +23,7 @@ Deploying a smart contract in Starknet requires two steps:
 
 [TIP]
 ====
-If you require an example smart contract to test with, you can use a pre prepared example from the Starknet Book link:https://github.com/starknet-edu/starknetbook/blob/main/examples/vote-contracts/src/lib.cairo[here].
+If you require an example smart contract for testing, you can use this link:https://github.com/starknet-edu/starknetbook/blob/main/examples/vote-contracts/src/lib.cairo[example from the Starknet Book].
 ====
 
 == Compiling a smart contract

--- a/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
+++ b/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
@@ -23,7 +23,7 @@ Deploying a smart contract in Starknet requires two steps:
 
 [TIP]
 ====
-If you require a smart contract for testing, you can use this sample contract, link:https://github.com/starknet-edu/starknetbook/blob/main/examples/vote-contracts/src/lib.cairo[`lib.cairo`], from the Starknet Book].
+If you require a smart contract for testing, you can use this sample contract, link:https://github.com/starknet-edu/starknetbook/blob/main/examples/vote-contracts/src/lib.cairo[`lib.cairo`], from the Starknet Book.
 ====
 
 == Compiling a smart contract

--- a/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
+++ b/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
@@ -23,7 +23,7 @@ Deploying a smart contract in Starknet requires two steps:
 
 [TIP]
 ====
-If you require an example smart contract to test with, you can use a pre prepared example from the Starknet Book link:https://github.com/starknet-edu/starknetbook/blob/main/chapters/book/modules/chapter_1/pages/contracts/src/lib.cairo[here].
+If you require an example smart contract to test with, you can use a pre prepared example from the Starknet Book link:https://github.com/starknet-edu/starknetbook/blob/main/examples/vote-contracts/src/lib.cairo[here].
 ====
 
 == Compiling a smart contract

--- a/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
+++ b/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
@@ -23,7 +23,7 @@ Deploying a smart contract in Starknet requires two steps:
 
 [TIP]
 ====
-If you require an example smart contract for testing, you can use this link:https://github.com/starknet-edu/starknetbook/blob/main/examples/vote-contracts/src/lib.cairo[example from the Starknet Book].
+If you require a smart contract for testing, you can use this sample contract, link:https://github.com/starknet-edu/starknetbook/blob/main/examples/vote-contracts/src/lib.cairo[`lib.cairo`], from the Starknet Book].
 ====
 
 == Compiling a smart contract


### PR DESCRIPTION
updated old link to example contracts folder

### Description of the Changes

Link to example contracts is not found - 404. I updated it to the new examples folder.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1077)
<!-- Reviewable:end -->
