### PR TITLE
docs: Describe contract nonce. Changed title to Contract classes and instances in contract-classes.adoc

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/nav.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/nav.adoc
@@ -22,7 +22,7 @@
 *** xref:Accounts/simplified_transaction_flow.adoc[Simplified transaction flow]
 
 ** Contracts
-*** xref:Smart_Contracts/contract-classes.adoc[Contract classes]
+*** xref:Smart_Contracts/contract-classes.adoc[Contract classes and instances]
 *** xref:Smart_Contracts/class-hash.adoc[Class hash]
 *** xref:Smart_Contracts/contract-address.adoc[Contract address]
 *** xref:Smart_Contracts/contract-storage.adoc[Contract storage]

--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-classes.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-classes.adoc
@@ -20,7 +20,7 @@ A contract class does not necessarily have a deployed instance in Starknet.
 A contract class does not necessarily require a deployed instance in Starknet.
 ====
 
-#A contract instance has a nonce, the value of which is the number of transactions originating from this address plus 1. For example, when you deploy an account with a `DEPLOY_ACCOUNT` transaction, the nonce of the account contract in the transaction is `0`. After the transaction, until the account contract sends its first transaction, the nonce is `1`.#
+A contract instance has a nonce, the value of which is the number of transactions originating from this address plus 1. For example, when you deploy an account with a `DEPLOY_ACCOUNT` transaction, the nonce of the account contract in the transaction is `0`. After the `DEPLOY_ACCOUNT` transaction, until the account contract sends its next transaction, the nonce is `1`.
 
 == Working with classes
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-classes.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-classes.adoc
@@ -20,6 +20,8 @@ A contract class does not necessarily have a deployed instance in Starknet.
 A contract class does not necessarily require a deployed instance in Starknet.
 ====
 
+#A contract instance has a nonce, the value of which is the number of transactions originating from this address plus 1. For example, when you deploy an account with a `DEPLOY_ACCOUNT` transaction, the nonce of the account contract in the transaction is `0`. After the transaction, until the account contract sends its first transaction, the nonce is `1`.#
+
 == Working with classes
 
 [horizontal,labelwidth=20,role="stripes-odd"]

--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-classes.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/contract-classes.adoc
@@ -1,15 +1,15 @@
 [id="contract_classes"]
-= Contract classes
+= Contract classes and instances
 
 As in object-oriented programming, Starknet distinguishes between a contract and its implementation by separating contracts into classes and instances.
 
-== Contract Classes
+== Contract classes
 
 A _contract class_ is the definition of a contract. It includes Cairo byte code, hint information, entry point names, and everything that defines its semantics.
 
 Each class is uniquely identified by its _class hash_, comparable to a class name in traditional object-oriented programming languages.
 
-== Contract Instances
+== Contract instances
 
 A _contract instance_ is a deployed contract that corresponds to a class. Only contract instances act as true contracts, in that they have their own storage and can be called by transactions or other contracts.
 
@@ -20,7 +20,7 @@ A contract class does not necessarily have a deployed instance in Starknet.
 A contract class does not necessarily require a deployed instance in Starknet.
 ====
 
-== Working with Classes
+== Working with classes
 
 [horizontal,labelwidth=20,role="stripes-odd"]
 Adding new classes:: To introduce new classes to Starknet's state, use the `DECLARE` transaction.
@@ -29,7 +29,7 @@ Deploying instances:: To deploy a new instance of a previously declared class, u
 
 Using class functionality:: To use the functionality of a declared class without deploying an instance, use the `library_call` system call. Analogous to Ethereum's `delegatecall`, it enables you to use code in an existing class without deploying a contract instance.
 
-== Additional Resources
+== Additional resources
 
 * xref:architecture_and_concepts:Smart_Contracts/class-hash.adoc[Class hash]
 * xref:architecture_and_concepts:Network_Architecture/transactions.adoc#declare-transaction[`DECLARE` transaction]


### PR DESCRIPTION
### Description of the Changes

Changed title to **Contract classes and instances** in contract-classes.adoc, and addresses #1098.

### PR Preview URL

[Contract classes and instances](https://starknet-io.github.io/starknet-docs/pr-1099/documentation/architecture_and_concepts/Smart_Contracts/contract-classes/)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1099)
<!-- Reviewable:end -->
