### PR TITLE
doc: Add addresses for L2 STRK and vSTRK.

### DIFF
--- a/components/Starknet/modules/tools/pages/important_addresses.adoc
+++ b/components/Starknet/modules/tools/pages/important_addresses.adoc
@@ -29,21 +29,18 @@ Sequencer base URL for API routing:: \https://alpha-sepolia.starknet.io
 
 The Starknet fee tokens are STRK and ETH.
 
-=== L2 ETH address
 
-This address is the same for testnet and Mainnet.
 
-[horizontal, labelwidth="15",role="stripes-odd"]
-L2 ETH token address:: link:https://starkscan.co/contract/0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7[`0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7`]
-
-=== STRK address
 
 [horizontal, labelwidth="15",role="stripes-odd"]
-L2 STRK token address:: link:https://starkscan.co/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[`0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d`]
+L2 STRK address (Mainnet and testnet):: link:https://starkscan.co/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[`0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d`]
+L2 ETH address (Mainnet and testnet):: link:https://starkscan.co/contract/0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7[`0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7`]
 
 == Starknet voting token
 
 The Starknet voting token is vSTRK. For information on vSTRK, see link:https://governance.starknet.io/learn/vstrk_overview[_vSTRK overview_] on the Starknet Governance Hub.
 
 [horizontal, labelwidth="15",role="stripes-odd"]
-L2 vSTRK token address:: link:https://starkscan.co/contract/0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f[`0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f`]
+Mainnet address:: link:https://starkscan.co/contract/0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f[`0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f`]
+Sepolia testnet address:: link:https://starkscan.co/contract/0x035c332b8de00874e702b4831c84b22281fb3246f714475496d74e644f35d492[`0x035c332b8de00874e702b4831c84b22281fb3246f714475496d74e644f35d492`]
+Goerli testnet address:: link:https://starkscan.co/contract/0x01a881a75bb478cedfd4d3ea19d2a4564350d78ea463a5287833526a416d5e31[`0x01a881a75bb478cedfd4d3ea19d2a4564350d78ea463a5287833526a416d5e31`]

--- a/components/Starknet/modules/tools/pages/important_addresses.adoc
+++ b/components/Starknet/modules/tools/pages/important_addresses.adoc
@@ -25,11 +25,25 @@ The Starknet Core Contract:: link:https://sepolia.etherscan.io/address/0xE2Bb56e
 Verifier address::  link:https://sepolia.etherscan.io/address/0x07ec0D28e50322Eb0C159B9090ecF3aeA8346DFe[`0x07ec0D28e50322Eb0C159B9090ecF3aeA8346DFe`^]
 Sequencer base URL for API routing:: \https://alpha-sepolia.starknet.io
 
-== Starknet fee token
+== Starknet fee tokens
 
-The Starknet fee token is currently ETH.
+The Starknet fee tokens are STRK and ETH.
+
+=== L2 ETH address
 
 This address is the same for testnet and Mainnet.
 
 [horizontal, labelwidth="15",role="stripes-odd"]
-L2 token address:: link:https://starkscan.co/contract/0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7[`0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7`]
+L2 ETH token address:: link:https://starkscan.co/contract/0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7[`0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7`]
+
+=== STRK address
+
+[horizontal, labelwidth="15",role="stripes-odd"]
+L2 STRK token address:: link:https://starkscan.co/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[`0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d`]
+
+== Starknet voting token
+
+The Starknet voting token is vSTRK. For information on vSTRK, see link:https://governance.starknet.io/learn/vstrk_overview[_vSTRK overview_] on the Starknet Governance Hub.
+
+[horizontal, labelwidth="15",role="stripes-odd"]
+L2 vSTRK token address:: link:https://starkscan.co/contract/0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f[`0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f`]


### PR DESCRIPTION
### Description of the Changes

Add addresses for L2 STRK and vSTRK.

### PR Preview URL

[Starknet contracts and sequencer addresses](https://starknet-io.github.io/starknet-docs/pr-1137/documentation/tools/important_addresses/)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


