### PR TITLE
Update transaction-life-cycle.adoc with a note on rejected transactions

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -39,22 +39,22 @@ The following are the possible statuses of a transaction from the moment a user 
 |Status type |Status |Explanation
 
 .5+|*Finality* |`NOT_RECEIVED` |The transaction is not yet known to the sequencer.
-|`RECEIVED` |The transaction was received by the mempool. The transaction now either executes successfully, is rejected, or reverted.
-|`REJECTED` |The transaction was received by the mempool but failed validation in the sequencer. Such transactions are not included in a block.
+|`RECEIVED` a|The transaction was received by the mempool. The transaction now either executes successfully, is rejected, or reverted.
++
+The transaction has no execution status.
+|`REJECTED` a|The transaction was received by the mempool but failed validation in the sequencer. Such transactions are not included in a block.
++
+The transaction has no execution status.
++
+[NOTE]
+====
+A `REJECTED` transaction is stored in the mempool. You cannot send another transaction with the same transaction hash.
+====
 |`ACCEPTED_ON_L2` |The transaction was executed and entered an actual created block on L2.
 |`ACCEPTED_ON_L1` |The transaction was accepted on Ethereum.
 .2+|*Execution* |`REVERTED` |The transaction passed validation but failed during execution in the sequencer. It is included in the block with the status `REVERTED`.
 |`SUCCEEDED` |The transaction was successfully executed by the sequencer. It is included in the block.
 |===
-
-[NOTE]
-====
-If the finality status of a transaction is `RECEIVED` or `REJECTED`, the transaction does not have an execution status.
-====
-[NOTE]
-====
-A `REJECTED` transaction is stored in the mempool. You cannot send another transaction with the same transaction hash.
-====
 
 [id="transaction-state-implications"]
 == State implications of a reverted transaction

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -46,6 +46,7 @@ The transaction has no execution status.
 
 The transaction has no execution status.
 
+
 [NOTE]
 ====
 A `REJECTED` transaction is stored in the mempool. You cannot send another transaction with the same transaction hash.

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -53,7 +53,7 @@ If the finality status of a transaction is `RECEIVED` or `REJECTED`, the transac
 ====
 [NOTE]
 ====
-A `REJECTED` transaction is stored in the mempool and another transaction with the same transaction hash cannot be sent again.
+A `REJECTED` transaction is stored in the mempool. You cannot send another transaction with the same transaction hash.
 ====
 
 [id="transaction-state-implications"]

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -40,12 +40,9 @@ The following are the possible statuses of a transaction from the moment a user 
 
 .5+|*Finality* |`NOT_RECEIVED` |The transaction is not yet known to the sequencer.
 |`RECEIVED` a|The transaction was received by the mempool. The transaction now either executes successfully, is rejected, or reverted.
-+
 The transaction has no execution status.
 |`REJECTED` a|The transaction was received by the mempool but failed validation in the sequencer. Such transactions are not included in a block.
-+
 The transaction has no execution status.
-+
 [NOTE]
 ====
 A `REJECTED` transaction is stored in the mempool. You cannot send another transaction with the same transaction hash.

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -40,9 +40,12 @@ The following are the possible statuses of a transaction from the moment a user 
 
 .5+|*Finality* |`NOT_RECEIVED` |The transaction is not yet known to the sequencer.
 |`RECEIVED` a|The transaction was received by the mempool. The transaction now either executes successfully, is rejected, or reverted.
+
 The transaction has no execution status.
 |`REJECTED` a|The transaction was received by the mempool but failed validation in the sequencer. Such transactions are not included in a block.
+
 The transaction has no execution status.
+
 [NOTE]
 ====
 A `REJECTED` transaction is stored in the mempool. You cannot send another transaction with the same transaction hash.

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -51,6 +51,10 @@ The following are the possible statuses of a transaction from the moment a user 
 ====
 If the finality status of a transaction is `RECEIVED` or `REJECTED`, the transaction does not have an execution status.
 ====
+[NOTE]
+====
+A `REJECTED` transaction is stored in the mempool and another transaction with the same transaction hash cannot be sent again.
+====
 
 [id="transaction-state-implications"]
 == State implications of a reverted transaction


### PR DESCRIPTION
### Description of the Changes

Added a note that if a transaction is rejected, then another transaction with the same transaction hash cannot be sent.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1141/documentation/architecture_and_concepts/Network_Architecture/transaction-life-cycle/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


