### PR TITLE
fix: Ignore "afe" when checking for typos. (from xiaolou86 in PR#1097)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -5,3 +5,6 @@ check-file = false
 extend-glob = ["*.adoc"]
 check-file = true
 
+[default.extend-words]
+# Don't correct the word
+afe = "afe"


### PR DESCRIPTION
### Description of the Changes

Adding this fix from @xiaolou86 from PR#1097, which has other changes that are taking longer to get reviewed.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


