### PR TITLE
fix: Update validation info in transaction_lifecycle.adoc

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -13,10 +13,13 @@ The high-level steps in the Starknet transaction lifecycle are as follows:
 
 . *Mempool validation:*
 The mempool performs a preliminary validation on the transaction. If the transaction is invalid, it does not proceed.
++
+Validation in this context is analogous to Ethereum's signature checking, including running the account's `+__validate__+` function on an `INVOKE` transaction, `+__validate_declare__+` on a `DECLARE` transaction, or `+__validate_deploy__+` on a `DEPLOY_ACCOUNT` transaction, ensuring that the current account balance exceeds the value of `max_fee` (prior to v3 transactions), and more.
 
 . *Sequencer validation:* The sequencer performs preliminary validation on the transaction before executing it to ensure that the transaction is still valid. If the transaction is invalid, it does not proceed.
 +
-Validation in this context is analogous to Ethereum's signature checking, including running the account's `+__validate__+` function, ensuring that the current account balance exceeds the value of `max_fee` (prior to v3 transactions), and more.
+This validation stage repeats the same validation run during the Mempool validation.
+//in this context is analogous to Ethereum's signature checking, including running the account's `+__validate__+` function on an `INVOKE` transaction, `+__validate_declare__+` on a `DECLARE` transaction, or `+__validate_deploy__+` on a `DEPLOY_ACCOUNT` transaction, ensuring that the current account balance exceeds the value of `max_fee` (prior to v3 transactions), and more.
 +
 include::partial$snippet_v3_max_price_sidebar.adoc[]
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -14,7 +14,7 @@ The high-level steps in the Starknet transaction lifecycle are as follows:
 . *Mempool validation:*
 The mempool performs a preliminary validation on the transaction. If the transaction is invalid, it does not proceed.
 +
-Validation in this context is analogous to Ethereum's signature checking, including running the account's `+__validate__+` function on an `INVOKE` transaction, `+__validate_declare__+` on a `DECLARE` transaction, or `+__validate_deploy__+` on a `DEPLOY_ACCOUNT` transaction, ensuring that the current account balance exceeds the value of `max_fee` (prior to v3 transactions), and more.
+Mempool validation in this context is analogous to Ethereum's signature checking, including running the account's `+__validate__+` function on an `INVOKE` transaction, `+__validate_declare__+` on a `DECLARE` transaction, or `+__validate_deploy__+` on a `DEPLOY_ACCOUNT` transaction, ensuring that the current account balance exceeds the value of `max_fee` (prior to v3 transactions), and more.
 
 . *Sequencer validation:* The sequencer performs preliminary validation on the transaction before executing it to ensure that the transaction is still valid. If the transaction is invalid, it does not proceed.
 +


### PR DESCRIPTION
### Description of the Changes

Clarifying which type of validation is run on which type of transaction, and that the same validation is run during the mempool stage and the sequencer stage.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


