### PR TITLE
docs: Update date of Goerli removal, Starknet CLI, in deprecated.adoc

### DIFF
--- a/components/Starknet/modules/ROOT/partials/snippet_important_goerli2_removed.adoc
+++ b/components/Starknet/modules/ROOT/partials/snippet_important_goerli2_removed.adoc
@@ -1,4 +1,6 @@
 [IMPORTANT]
 ====
-Goerli testnet 2 is removed. Use Goerli testnet.
+Goerli testnet 2 is removed. Goerli testnet support will be removed April 11, 2024. Sepolia testnet replaces Goerli testnet.
+
+For more information, including bridge support for Sepolia, see link:http://eepurl.com/iK0YTE[Starknet Goerli Deprecation] in the Starknet Dev News newsletter.
 ====

--- a/components/Starknet/modules/starknet_versions/pages/deprecated.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/deprecated.adoc
@@ -25,7 +25,7 @@ Removed:: Refers to a feature or capability that has been entirely removed.
 |Name|Description
 
 | Goerli testnet
-a| Goerli testnet is deprecated and is being replaced by Sepolia testnet. Starknet started migrating to Sepolia testnet on November 15th, 2023. Goerli testnet support will be removed in the upcoming months. You should migrate to Sepolia testnet as soon as possible. For more information on the Goerli deprecation, see https://ethereum.org/nb/developers/docs/networks/#ethereum-testnets[the deprecation announcement on Ethereum's site].
+a| Goerli testnet is deprecated and is being replaced by Sepolia testnet. Starknet started migrating to Sepolia testnet on November 15th, 2023. Goerli testnet support will be removed April 11, 2024. You should migrate to Sepolia testnet as soon as possible. For more information on the Goerli deprecation, see https://ethereum.org/nb/developers/docs/networks/#ethereum-testnets[the deprecation announcement on Ethereum's site].
 
 Full nodes, API services, SDKs, and other Starknet developer tools have started their migration to Sepolia as well. Builders are urged to migrate to Sepolia as soon as possible.
 
@@ -34,9 +34,9 @@ Full nodes, API services, SDKs, and other Starknet developer tools have started 
 Sepolia's state and history are relatively small. Sepolia xref:version_notes.adoc[supports declaring classes of Cairo v0 and Cairo v2.0.0 and higher].
 ====
 
-|Starknet CLI | The Starknet CLI is deprecated. Instead use xref:cli:starkli.adoc[Starkli].
+|Starknet CLI | Support for the Starknet CLI has been removed. Instead use xref:cli:starkli.adoc[Starkli].
 
-Support for Starknet CLI will be removed in Starknet v0.13.0.
+Support for Starknet CLI is removed in Starknet v0.13.0.
 |Cairo 0 | xref:starknet_versions:version_notes.adoc#version0.11.0[Starknet v0.11.0] introduces Cairo 1.0 smart contracts.
 |===
 


### PR DESCRIPTION
### Description of the Changes

Remove support for Starknet CLI, added date for Goerli removal.

### PR Preview URL

[Starknet release notes](https://starknet-io.github.io/starknet-docs/pr-1154/documentation/starknet_versions/version_notes/)
[Deprecated, unsupported, and removed features](https://starknet-io.github.io/starknet-docs/pr-1154/documentation/starknet_versions/deprecated/)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


