### PR TITLE
docs: minor readme update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -106,21 +106,21 @@ Hit CTRL-C to stop the server
 
 ----
 
-== Releasing Starknet docs on Github (for Admins only)
+== Releasing Starknet docs on GitHub (for Admins only)
 
 _The high-level process for releasing documentation changes in this repository._
 
 During the course of content development, writers merge branches with changes either directly into `main`, into a secondary branch as needed, where these changes wait until we are ready to release them—that is, post them to link:https://docs.starknet.io[docs.starknet.io].
 
-Github actions create Git tags and releases that appear at the repo’s link:https://github.com/starknet-community-libs/starknet-docs/releases[Releases] and link:https://github.com/starknet-community-libs/starknet-docs/tags[Tags] pages.
+GitHub actions create Git tags and releases that appear at the repo’s link:https://github.com/starknet-community-libs/starknet-docs/releases[Releases] and link:https://github.com/starknet-community-libs/starknet-docs/tags[Tags] pages.
 
-When a feature branch is merged into the `main` branch, a github action creates a release tag in the format `v<version>.<major_update>.<minor_update>` and updates `CHANGELOG.md`. It then publishes the new content to docs.starknet.io.
+When a feature branch is merged into the `main` branch, a GitHub action creates a release tag in the format `v<version>.<major_update>.<minor_update>` and updates `CHANGELOG.md`. It then publishes the new content to docs.starknet.io.
 
 === Procedure
 
 Merging a feature branch to `main` automatically publishes changes in the feature branch. No additional steps are required.
 
-Github increments the version numbers in `package.json` and `package-lock.json`, and updates `CHANGELOG.md` with the descriptions of each PR that was just merged into `main`.
+GitHub increments the version numbers in `package.json` and `package-lock.json`, and updates `CHANGELOG.md` with the descriptions of each PR that was just merged into `main`.
 . Update your local `main` branch from the remote `main` branch using one of the following:
 
 * Pull the changes:


### PR DESCRIPTION
### Description of the Changes

Change Github to GitHub in the README, that's it.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


