### PR TITLE
docs: Update version_notes.adoc with 0.13.1 release notes

### DIFF
--- a/components/Starknet/modules/starknet_versions/nav.adoc
+++ b/components/Starknet/modules/starknet_versions/nav.adoc
@@ -1,4 +1,3 @@
-* Versions
-** xref:version_notes.adoc[Starknet release notes]
-// ** xref:upcoming_versions.adoc[Upcoming Starknet versions]
+* Release information
+** xref:version_notes.adoc[Release notes]
 ** xref:deprecated.adoc[Deprecated, unsupported, and removed features]

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -23,6 +23,7 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 [id="version0.13.1"]
 == Starknet v0.13.1
 
+[discrete]
 === New features and enhancements
 
 * *Cheaper data availability:* Starknet uses link:https://eips.ethereum.org/EIPS/eip-4844[EIP-4844].
@@ -32,6 +33,7 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 * *Optimization:* Load only the used functions in a contract into memory when generating the proof.
 * Add `starknet-compiled-class-hash` command.
 
+[discrete]
 === API changes:
 
 Starknet block:
@@ -43,6 +45,7 @@ Starknet block:
 ** syscall resources, which contribute to the transaction fee but were not included in the receipt before this version.
 * `transaction_commitment` and `event_commitment` are added to the block (zero is returned for old blocks)
 
+[discrete]
 === Technical changes:
 
 Starknet now supports multiple L1 providers.

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -24,31 +24,32 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 
 [id="version0.13.1"]
 == Starknet v0.13.1
-* Use link:https://eips.ethereum.org/EIPS/eip-4844[EIP 4844] for cheaper data availability
 
-* Time-related syscalls when called from account contract's `__validate__`:
-** `timestamp` will return the hour, rounded down
-** `block_number` will return the block number rounded down to the nearest multiple of 100
-* Optimization: Load only the used functions in a contract into memory when generating the proof
-
+* *Cheaper data availability:* Starknet uses link:https://eips.ethereum.org/EIPS/eip-4844[EIP-4844].
+* Time-related syscalls when called from account contract's `__validate__` function:
+** `timestamp` returns the hour, rounded down.
+** `block_number` returns the block number, rounded down to the nearest multiple of 100.
+* *Optimization:* Load only the used functions in a contract into memory when generating the proof
 * Add `starknet-compiled-class-hash` command
 
-* API changes:
-** Starknet block:
-*** New field `l1_da_mode`, which indicates whether EIP 4844 was used in the block
-*** `eth_l1_gas_price` and `strk_l1_gas_price` were replaced, and the information now contains the data gas price (EIP 4844) in addition to the regular gas price
-*** `execution_resources` in transaction receipt now contains:
-**** data availability resources
-**** syscall resources (which contribute to the transaction fee but were not included in the receipt until this version)
-*** `transaction_commitment` and `event_commitment` are added to the block (zero is returned for old blocks)
+=== API changes:
 
-* Technical changes:
-** Support multiple L1 providers
+* Starknet block:
+** New field `l1_da_mode`, which indicates whether EIP-4844 was used in the block.
+** `eth_l1_gas_price` and `strk_l1_gas_price` were replaced, and the information now contains the data gas price (EIP 4844) in addition to the regular gas price
+** `execution_resources` in the transaction receipt now contains:
+*** data availability resources
+*** syscall resources, which contribute to the transaction fee but were not included in the receipt before this version.
+** `transaction_commitment` and `event_commitment` are added to the block (zero is returned for old blocks)
+
+=== Technical changes:
+
+* Starknet now supports multiple L1 providers.
 
 For more details see the link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664[community forum post].
 
 [id="version0.13.0"]
-== Starknet v0.13.0
+== Starknet v0.13.0 (Jan 10, 23)
 
 Starknet v0.13.0 is live on Mainnet.
 
@@ -64,7 +65,7 @@ Starknet 0.13.0 includes the following changes:
 
 
 [id="version0.12.3"]
-== Starknet v0.12.3 (November 19th 23)
+== Starknet v0.12.3 (Nov 19, 23)
 
 Starknet v0.12.3 is live on Mainnet.
 
@@ -89,7 +90,7 @@ Move structs that are common to `secp256k1` and `secp256r1` to a separate file.
 
 
 [id="version0.12.2"]
-== Starknet v0.12.2 (September 4th 23)
+== Starknet v0.12.2 (Sep 04, 23)
 
 Starknet v0.12.2 is live on Mainnet.
 
@@ -100,7 +101,7 @@ This version includes the following changes:
 * Increased maximum Cairo steps per transaction from 1 million to 3 million.
 
 [id="version0.12.1"]
-== Starknet v0.12.1 (August 21st 23)
+== Starknet v0.12.1 (Aug 21, 23)
 
 Starknet v0.12.1 is live on Mainnet.
 
@@ -111,7 +112,7 @@ This version includes the following changes:
 * Keccak builtin.
 
 [id="version0.12.0"]
-== Starknet v0.12.0 (July 12th, 23)
+== Starknet v0.12.0 (July 12, 23)
 
 Starknet v0.12.0 is live on Mainnet.
 
@@ -291,7 +292,7 @@ Technical changes:
 
 [id="version0.9.1"]
 == Starknet v0.9.1 (July 20, 22)
-
+November
 This version contains the following changes:
 
 Starknet:

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -21,6 +21,32 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 |Goerli Testnet (deprecated)|0.13.0|1.4.0|2.0.0 - 2.5.4
 |===
 
+
+[id="version0.13.1"]
+== Starknet v0.13.1
+* Use link:https://eips.ethereum.org/EIPS/eip-4844[EIP 4844] for cheaper data availability
+
+* Time-related syscalls when called from account contract's `__validate__`:
+** `timestamp` will return the hour, rounded down
+** `block_number` will return the block number rounded down to the nearest multiple of 100
+* Optimization: Load only the used functions in a contract into memory when generating the proof
+
+* Add `starknet-compiled-class-hash` command
+
+* API changes:
+** Starknet block:
+*** New field `l1_da_mode`, which indicates whether EIP 4844 was used in the block
+*** `eth_l1_gas_price` and `strk_l1_gas_price` were replaced, and the information now contains the data gas price (EIP 4844) in addition to the regular gas price
+*** `execution_resources` in transaction receipt now contains:
+**** data availability resources
+**** syscall resources (which contribute to the transaction fee but were not included in the receipt until this version)
+*** `transaction_commitment` and `event_commitment` are added to the block (zero is returned for old blocks)
+
+* Technical changes:
+** Support multiple L1 providers
+
+For more details see the link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664[community forum post].
+
 [id="version0.13.0"]
 == Starknet v0.13.0
 

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -33,6 +33,19 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 * *Optimization:* Load into memory only the functions in a contract that are actually used when generating the proof.
 
 [discrete]
+=== Pricing changes
+
+[cols="1,2"]
+|===
+| Computation | The Cairo step price is reduced by a factor of 2x, and will now cost 0.0025 gas/step. This also means that the costs of all builtins are halved accordingly.
+| Calldata and signatures | Each felt in the calldata and signature arrays of all transaction types is now priced at 0.128 gas/felt
+| Class declaration | Each felt of sierra_program in the contract class and of bytecode in the compiled contract class is now priced at 28 gas/felt (note that for v1 declares, we only have bytecode).
+
+Additionally, each character in the ABI costs 0.875 gas.
+| Events | An additional felt to the data array of an event now costs 0.128 gas/felt (similarly to calldata). An additional felt to the keys array now costs 0.256 gas/felt.
+|===
+
+[discrete]
 === API changes:
 
 Starknet block:

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -42,14 +42,23 @@ Starknet block:
 * `execution_resources` in the transaction receipt now contains:
 ** data availability resources
 ** syscall resources, which contribute to the transaction fee but were not included in the receipt before this version.
-* `transaction_commitment` and `event_commitment` are added to the block (zero is returned for old blocks)
+* `transaction_commitment` and `event_commitment` are added to the block. `0` is returned for old blocks.
 
 [discrete]
 === Infrastructure updates
 
 Starknet now supports multiple L1 providers.
 
-For more details see the link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664[community forum post].
+[discrete]
+=== Additional resources
+
+Community Forum Posts:
+
+* link:https://community.starknet.io/t/starknet-v0-13-1-eip4844-support-more-fee-reductions-stability-quality-of-life/112951[Starknet v0.13.1: EIP4844 Support, More Fee Reductions, Stability, Quality of Life]
+* link:https://community.starknet.io/t/starknet-v0-13-1-fee-reduction/113552[Starknet v0.13.1: Fee Reduction]
+* link:https://community.starknet.io/t/data-availability-with-eip4844/113065[Data availability with EIP4844]
+* link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664[Starknet v0.13.1 pre-release notes]
+
 
 [id="version0.13.0"]
 == Starknet v0.13.0 (Jan 10, 23)

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -35,15 +35,32 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 [discrete]
 === Pricing changes
 
-[cols="1,2"]
-|===
-| Computation | The Cairo step price is reduced by a factor of 2x, and will now cost 0.0025 gas/step. This also means that the costs of all builtins are halved accordingly.
-| Calldata and signatures | Each felt in the calldata and signature arrays of all transaction types is now priced at 0.128 gas/felt
-| Class declaration | Each felt of sierra_program in the contract class and of bytecode in the compiled contract class is now priced at 28 gas/felt (note that for v1 declares, we only have bytecode).
+[discrete]
+==== Computation
 
-Additionally, each character in the ABI costs 0.875 gas.
-| Events | An additional felt to the data array of an event now costs 0.128 gas/felt (similarly to calldata). An additional felt to the keys array now costs 0.256 gas/felt.
-|===
+* A Cairo step now costs 0.0025 gas/step, a 50% reduction.
+* All builtins costs are accordingly reduced by 50%.
+
+[discrete]
+==== Calldata and signatures
+
+Each felt in the calldata and signature arrays of all transaction types now costs 0.128 gas/felt.
+
+[discrete]
+==== Class declaration
+* Each felt of a sierra_program in the contract class and of bytecode in the compiled contract class now costs 28 gas/felt.
++
+[NOTE]
+====
+v1 `DECLARE` transactions only include bytecode.
+====
+* Each character in the ABI costs 0.875 gas.
+
+[discrete]
+==== Events
+
+* An additional felt to the data array of an event now costs 0.128 gas/felt, similar to calldata.
+* An additional felt to the keys array now costs 0.256 gas/felt.
 
 [discrete]
 === API changes:

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -27,7 +27,7 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 === New features and enhancements
 
 * *Cheaper data availability:* Starknet uses link:https://eips.ethereum.org/EIPS/eip-4844[EIP-4844].
-* Time-related syscalls when called from an account contract's `__validate__` function:
+* Time-related syscalls when called from an account contract's `+__validate__+` function:
 ** `timestamp` returns the hour, rounded down.
 ** `block_number` returns the block number, rounded down to the nearest multiple of 100.
 * *Optimization:* Load into memory only the functions in a contract that are actually used when generating the proof.

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -30,13 +30,13 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 ** `timestamp` returns the hour, rounded down.
 ** `block_number` returns the block number, rounded down to the nearest multiple of 100.
 * *Optimization:* Load only the used functions in a contract into memory when generating the proof.
-* Add `starknet-compiled-class-hash` command
+* Add `starknet-compiled-class-hash` command.
 
 === API changes:
 
 * Starknet block:
 ** New field `l1_da_mode`, which indicates whether EIP-4844 was used in the block.
-** `eth_l1_gas_price` and `strk_l1_gas_price` were replaced, and the information now contains the data gas price (EIP 4844) in addition to the regular gas price
+** `eth_l1_gas_price` and `strk_l1_gas_price` were replaced, and the information now contains the data gas price (EIP-4844) in addition to the regular gas price
 ** `execution_resources` in the transaction receipt now contains:
 *** data availability resources
 *** syscall resources, which contribute to the transaction fee but were not included in the receipt before this version.

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -26,10 +26,10 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 == Starknet v0.13.1
 
 * *Cheaper data availability:* Starknet uses link:https://eips.ethereum.org/EIPS/eip-4844[EIP-4844].
-* Time-related syscalls when called from account contract's `__validate__` function:
+* Time-related syscalls when called from an account contract's `__validate__` function:
 ** `timestamp` returns the hour, rounded down.
 ** `block_number` returns the block number, rounded down to the nearest multiple of 100.
-* *Optimization:* Load only the used functions in a contract into memory when generating the proof
+* *Optimization:* Load only the used functions in a contract into memory when generating the proof.
 * Add `starknet-compiled-class-hash` command
 
 === API changes:
@@ -44,7 +44,7 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 
 === Technical changes:
 
-* Starknet now supports multiple L1 providers.
+Starknet now supports multiple L1 providers.
 
 For more details see the link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664[community forum post].
 

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -24,6 +24,7 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 == Starknet v0.13.1
 
 === New features and enhancements
+
 * *Cheaper data availability:* Starknet uses link:https://eips.ethereum.org/EIPS/eip-4844[EIP-4844].
 * Time-related syscalls when called from an account contract's `__validate__` function:
 ** `timestamp` returns the hour, rounded down.

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -292,7 +292,6 @@ Technical changes:
 
 [id="version0.9.1"]
 == Starknet v0.9.1 (July 20, 22)
-November
 This version contains the following changes:
 
 Starknet:

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -30,7 +30,7 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 * Time-related syscalls when called from an account contract's `__validate__` function:
 ** `timestamp` returns the hour, rounded down.
 ** `block_number` returns the block number, rounded down to the nearest multiple of 100.
-* *Optimization:* Load only the used functions in a contract into memory when generating the proof.
+* *Optimization:* Load into memory only the functions in a contract that are actually used when generating the proof.
 * Add `starknet-compiled-class-hash` command.
 
 [discrete]

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -5,7 +5,7 @@ The following release notes cover the ongoing version changes to Starknet. You c
 
 == Starknet environments
 
-Within Starknet's deployment pipeline there are separate and distinct networks that operate independently of each other for testing before deployment.
+Within Starknet's deployment pipeline, there are separate and distinct networks that operate independently of each other for testing before deployment.
 
 
 include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
@@ -16,15 +16,14 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 |Environment |Starknet version|Sierra version|Cairo version
 
 |Mainnet|0.13.0|1.4.0|2.0.0 - 2.5.4
-
-|Sepolia Testnet|0.13.0|1.4.0|2.0.0 - 2.5.4
+|Sepolia Testnet|0.13.1|1.5.0|2.0.0 - 2.6
 |Goerli Testnet (deprecated)|0.13.0|1.4.0|2.0.0 - 2.5.4
 |===
-
 
 [id="version0.13.1"]
 == Starknet v0.13.1
 
+=== New features and enhancements
 * *Cheaper data availability:* Starknet uses link:https://eips.ethereum.org/EIPS/eip-4844[EIP-4844].
 * Time-related syscalls when called from an account contract's `__validate__` function:
 ** `timestamp` returns the hour, rounded down.
@@ -34,13 +33,14 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 
 === API changes:
 
-* Starknet block:
-** New field `l1_da_mode`, which indicates whether EIP-4844 was used in the block.
-** `eth_l1_gas_price` and `strk_l1_gas_price` were replaced, and the information now contains the data gas price (EIP-4844) in addition to the regular gas price
-** `execution_resources` in the transaction receipt now contains:
-*** data availability resources
-*** syscall resources, which contribute to the transaction fee but were not included in the receipt before this version.
-** `transaction_commitment` and `event_commitment` are added to the block (zero is returned for old blocks)
+Starknet block:
+
+* New field `l1_da_mode`, which indicates whether EIP-4844 was used in the block.
+* `eth_l1_gas_price` and `strk_l1_gas_price` were replaced, and the information now contains the data gas price (EIP-4844) in addition to the regular gas price
+* `execution_resources` in the transaction receipt now contains:
+** data availability resources
+** syscall resources, which contribute to the transaction fee but were not included in the receipt before this version.
+* `transaction_commitment` and `event_commitment` are added to the block (zero is returned for old blocks)
 
 === Technical changes:
 

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -31,7 +31,6 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 ** `timestamp` returns the hour, rounded down.
 ** `block_number` returns the block number, rounded down to the nearest multiple of 100.
 * *Optimization:* Load into memory only the functions in a contract that are actually used when generating the proof.
-* Add `starknet-compiled-class-hash` command.
 
 [discrete]
 === API changes:
@@ -46,7 +45,7 @@ Starknet block:
 * `transaction_commitment` and `event_commitment` are added to the block (zero is returned for old blocks)
 
 [discrete]
-=== Technical changes:
+=== Infrastructure updates
 
 Starknet now supports multiple L1 providers.
 


### PR DESCRIPTION
### Description of the Changes

Release notes taken from https://github.com/starkware-libs/cairo-lang/releases/tag/v0.13.1a0.

### PR Preview URL

[Release notes](https://starknet-io.github.io/starknet-docs/pr-1160/documentation/starknet_versions/version_notes/)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


