### PR TITLE
fix: Fix example in emit_events

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/starknet-events.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/starknet-events.adoc
@@ -35,18 +35,12 @@ To emit custom keys, one should use the low level `emit_event` system call:
 ----
 use starknet::syscalls::emit_event_syscall;
 
-let keys = ArrayTrait::new();
-keys.append('key');
-keys.append('deposit');
-let values = ArrayTrait::new();
-values.append(1);
-values.append(2);
-values.append(3);
+let keys = array!['key', 'deposit'];
+let values = array![1, 2, 3];
 emit_event_syscall(keys, values).unwrap_syscall();
 ----
 
-
-The above code emits an event with two keys, the https://www.cairo-lang.org/docs/how_cairo_works/consts.html#short-string-literals[strings] "status" and "deposit" (think of those as identifiers of the event that can be used for indexing) and three data elements 1, 2, 3.
+The above code emits an event with two keys, the https://www.cairo-lang.org/docs/how_cairo_works/consts.html#short-string-literals[strings] `key` and `deposit` (think of those as identifiers of the event that can be used for indexing) and three data elements 1, 2, 3.
 
 
 [TIP]

--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/system-calls-cairo1.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/system-calls-cairo1.adoc
@@ -209,17 +209,12 @@ link:https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994d
 [discrete]
 ==== Example
 
-The following example emits an event with two keys, the strings `status` and `deposit` and three data elements: `1`, `2`, and `3`.
+The following example emits an event with two keys, the strings `key` and `deposit` and three data elements: `1`, `2`, and `3`.
 
 [source,cairo]
 ----
-let keys = ArrayTrait::new();
-keys.append('key');
-keys.append('deposit');
-let values = ArrayTrait::new();
-values.append(1);
-values.append(2);
-values.append(3);
+let keys = array!['key', 'deposit'];
+let values = array![1, 2, 3];
 emit_event_syscall(keys, values).unwrap_syscall();
 ----
 


### PR DESCRIPTION
### Description of the Changes

1. The syscall emit_event example is incorrect, and the problem noted in num 2 also applies here.

2. https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/starknet-events/

    The above code emits an event with two keys, the [strings](https://www.cairo-lang.org/docs/how_cairo_works/consts.html#short-string-literals) “status” and “deposit”

     The code shown actually uses “key” and “deposit” as keys

### PR Preview URL

[Events](https://starknet-io.github.io/starknet-docs/pr-1169/documentation/architecture_and_concepts/Smart_Contracts/starknet-events/)
[emit_event](https://starknet-io.github.io/starknet-docs/pr-1169/documentation/architecture_and_concepts/Smart_Contracts/system-calls-cairo1/#emit_event)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1169)
<!-- Reviewable:end -->
