### PR TITLE
docs: Added new fields to block header for 0.13.1

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
@@ -21,6 +21,10 @@ In Starknet, a block is a list of transactions, and a block header that contains
 | `event_commitment` | `FieldElement` | A commitment to the events produced in this block | &#10003;
 | `protocol_version` | `Integer` | The version of the Starknet protocol used when creating this block |
 | `extra data` | `FieldElement` | Extraneous data that might be useful for running transactions |
+| `data_gas` |  |  |
+| `l1_da_mode` | `ByteArray` |  |
+| `l1_data_gas_price` |  | Contains `price_in_wei` and `price_in_fri`, where 1 fri is 10^-18^ STRK. Also appears in pending block. |
+| `l1_gas_price` |  | Replaces `eth_l1_gas_price` and `strk_l1_gas_price`. Contains the data gas price (EIP-4844) in addition to the regular gas price. |
 |===
 
 Where:


### PR DESCRIPTION
### Description of the Changes

Added new fields to block header for 0.13.1

### PR Preview URL

[Block structure](https://starknet-io.github.io/starknet-docs/pr-1173/documentation/architecture_and_concepts/Network_Architecture/header/)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1173)
<!-- Reviewable:end -->
