### PR TITLE
fix: Upload to prod server not working

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,10 +33,13 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         run: yarn run release
 
-      - name: Push to remote branch
-        uses: ad-m/github-push-action@master
-        with:
-          USER_TOKEN: ${{ secrets.USER_TOKEN }}
-          branch: ${{ github.ref }}
-          tags: true
-          force: true
+      - name: scp upload to production site
+        run: sshpass -p ${{ secrets.PROD_PASS }} scp -o 'StrictHostKeyChecking no' -r public_html/ ${{ secrets.PROD_USER }}@${{ secrets.PROD_IP }}:~/
+
+#      - name: Push to remote branch
+#        uses: ad-m/github-push-action@master
+#        with:
+#          USER_TOKEN: ${{ secrets.USER_TOKEN }}
+#          branch: ${{ github.ref }}
+#          tags: true
+#          force: true


### PR DESCRIPTION
### Description of the Changes

There is a step in push.yml that is not succeeding. It seems to just create a version tag. Upon creating the version tag, the tag.yml workflow runs. The last step in this workflow, after creating a Release, is to upload the site to the prod server.

Given that we wanted to remove the tag and release workflows from this repo anyway, I moved the upload step directly to the push.yml workflow, and skip the step to create a new version tag and new release.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1184)
<!-- Reviewable:end -->
