### PR TITLE
docs: update block header w.r.t Starknet 0.13.1

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
@@ -23,12 +23,12 @@ The root of a height-64 binary Merkle Patricia trie. The leaf at index stem:[$i$
 | `event_commitment` | `FieldElement` | A commitment to the events produced in the block.
 
 The root of a height-64 binary Merkle Patricia trie. The leaf at index stem:[$i$] corresponds to the hash of the stem:[$i'th$] event.
-| `l1_gas_price` | `(Integer~wei~, Integer~fri~)` | The price of L1 gas that was used while constructing the block. L1 gas prices apply to storage updates and L1->L2 messages. As of March 2023, computation is also priced in terms of L1 gas, but this will change in the future.
+| `l1_gas_price` | `(Integer, Integer)` | The price of L1 gas that was used while constructing the block. L1 gas prices apply to storage updates and L1->L2 messages. As of March 2023, computation is also priced in terms of L1 gas, but this will change in the future.
 
-`Integer~wei~` is the price in wei. `Integer~fri~` is the price in fri.
-| `l1_data_gas_price` | `(Integer~wei~, Integer~fri~)` | The price of L1 blob gas that was used while constructing the block. If the `l1_DA_MODE` of the block is set to `BLOB`, L1 blob gas prices determines the storage update cost.
+The first `Integer` value is the price in wei. The second is the price in fri.
+| `l1_data_gas_price` | `(Integer, Integer)` | The price of L1 blob gas that was used while constructing the block. If the `l1_DA_MODE` of the block is set to `BLOB`, L1 blob gas prices determines the storage update cost.
 
-`Integer~wei~` is the price in wei. `Integer~fri~` is the price in fri.
+The first `Integer` value is the price in wei. The second is the price in fri.
 | `l1_da_mode` | `String` | `CALLDATA` or `BLOB`, depending on how Starknet state diffs are sent to L1.
 | `protocol_version` | `String` | The version of the Starknet protocol used when creating the block.
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
@@ -8,19 +8,23 @@ In Starknet, a block is a list of transactions, and a block header that contains
 
 [%autowidth]
 |===
-| Name | Type | Description | Implemented
+| Name | Type | Description
 
-| `parent_block_hash` | `FieldElement` | The hash of this block's parent | &#10003;
-|`block_number` | `Integer` | The number (height) of this block | &#10003;
-| `global_state_root` | `FieldElement` | The state xref:../Network_Architecture/starknet-state.adoc#state_commitment[commitment] after this block | &#10003;
-|`sequencer_address` | `FieldElement` | The Starknet address of the sequencer who created this block | &#10003;
-| `block_timestamp` | `Timestamp` | The time the sequencer created this block before executing transactions | &#10003;
-|`transaction_count` | `Integer` | The number of transactions in a block | &#10003;
-| `transaction_commitment` | `FieldElement` | A commitment to the transactions included in the block | &#10003;
-|`event_count` | `Integer` | The number of events | &#10003;
-| `event_commitment` | `FieldElement` | A commitment to the events produced in this block | &#10003;
-| `protocol_version` | `Integer` | The version of the Starknet protocol used when creating this block |
-| `extra data` | `FieldElement` | Extraneous data that might be useful for running transactions |
+| `parent_block_hash` | `FieldElement` | The hash of this block's parent
+|`block_number` | `Integer` | The number (height) of this block
+| `global_state_root` | `FieldElement` | The state xref:../Network_Architecture/starknet-state.adoc#state_commitment[commitment] after this block
+|`sequencer_address` | `ContractAddress` | The Starknet address of the sequencer who created this block
+| `block_timestamp` | `Timestamp` | The time the sequencer created this block before executing transactions
+|`transaction_count` | `Integer` | The number of transactions in a block
+| `transaction_commitment` | `FieldElement` | A commitment to the transactions included in the block;
+|`event_count` | `Integer` | The number of events
+| `event_commitment` | `FieldElement` | A commitment to the events produced in this block
+| `l1_gas_price` | `(Integer, Integer)` | The price of L1 gas that was used while constructing this block. L1 gas prices are relevant for storage updates and L1→L2 messages (today, computation is also priced in terms of L1 gas, but this will change in the future). The price is specified in both wei and fri, hence the two numbers.
+| `l1_data_gas_price` | `(Integer, Integer)` | The price of L1 blob gas that was used while constructing this block. If the `l1_DA_MODE` of the block is set to `BLOB`, L1 blob gas prices will determine the storage update cost. The price is specified in both wei and fri, hence the two numbers.
+| `l1_da_mode` | `String` | `CALLDATA` or `BLOB`, depending on how Starknet state diffs are sent to L1
+| `protocol_version` | `Integer` | The version of the Starknet protocol used when creating this block.
+
+
 |===
 
 Where:
@@ -60,4 +64,9 @@ Where `_h_` is the xref:../../Cryptography/hash-functions.adoc#pedersen-hash[Ped
 [NOTE]
 ====
 Zeros inside the hash computation of an object are used as placeholders, to be replaced in the future by meaningful fields.
+====
+
+[NOTE]
+====
+Several properties of the block header, such as `l1_gas_price` and `l1_da_mode`, are not yet included in the block hash. This will change in a future Starknet version.
 ====

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
@@ -14,15 +14,15 @@ A Starknet block is a list of transactions and a block header that contains the 
 |`block_number` | `Integer` | The number, that is, the height, of this block.
 | `global_state_root` | `FieldElement` | The xref:../Network_Architecture/starknet-state.adoc#state_commitment[state commitment] after the block.
 |`sequencer_address` | `ContractAddress` | The Starknet address of the sequencer that created the block.
-| `block_timestamp` | `Timestamp` | The time the sequencer created the block, before executing transactions, in seconds since the Unix epoch.
+| `block_timestamp` | `Timestamp` | The time at which the sequencer began building the block, in seconds since the Unix epoch.
 |`transaction_count` | `Integer` | The number of transactions in the block.
 | `transaction_commitment` | `FieldElement` | A commitment to the transactions included in the block.
 
-The root of a 64-bit high binary Merkle Patricia trie. The leaf at index stem:[$i$] corresponds to stem:[$${h(transaction \space hash, signature)}$$] if the stem:[$i'th$] transaction is an `invoke` transaction and stem:[$h(0,0)$] otherwise.
+The root of a height-64 binary Merkle Patricia trie. The leaf at index stem:[$i$] corresponds to stem:[$${h(\text{transaction_hash}, \text{signature})}$$] if the stem:[$i'th$] transaction is an `invoke` transaction and stem:[$h(0,0)$] otherwise.
 |`event_count` | `Integer` | The number of events in the block.
 | `event_commitment` | `FieldElement` | A commitment to the events produced in the block.
 
-The root of a 64-bit high binary Merkle Patricia trie. The leaf at index stem:[$i$] corresponds to the hash of the stem:[$i'th$] event.
+The root of a height-64 binary Merkle Patricia trie. The leaf at index stem:[$i$] corresponds to the hash of the stem:[$i'th$] event.
 | `l1_gas_price` | `(Integer~wei~, Integer~fri~)` | The price of L1 gas that was used while constructing the block. L1 gas prices apply to storage updates and L1->L2 messages. As of March 2023, computation is also priced in terms of L1 gas, but this will change in the future.
 
 `Integer~wei~` is the price in wei. `Integer~fri~` is the price in fri.
@@ -30,7 +30,7 @@ The root of a 64-bit high binary Merkle Patricia trie. The leaf at index stem:[$
 
 `Integer~wei~` is the price in wei. `Integer~fri~` is the price in fri.
 | `l1_da_mode` | `String` | `CALLDATA` or `BLOB`, depending on how Starknet state diffs are sent to L1.
-| `protocol_version` | `Integer` | The version of the Starknet protocol used when creating the block.
+| `protocol_version` | `String` | The version of the Starknet protocol used when creating the block.
 
 
 |===

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/header.adoc
@@ -3,36 +3,44 @@
 [id="block_structure"]
 = Block structure
 
-In Starknet, a block is a list of transactions, and a block header that contains the following fields:
+A Starknet block is a list of transactions and a block header that contains the following fields:
 
 
 [%autowidth]
 |===
 | Name | Type | Description
 
-| `parent_block_hash` | `FieldElement` | The hash of this block's parent
-|`block_number` | `Integer` | The number (height) of this block
-| `global_state_root` | `FieldElement` | The state xref:../Network_Architecture/starknet-state.adoc#state_commitment[commitment] after this block
-|`sequencer_address` | `ContractAddress` | The Starknet address of the sequencer who created this block
-| `block_timestamp` | `Timestamp` | The time the sequencer created this block before executing transactions
-|`transaction_count` | `Integer` | The number of transactions in a block
-| `transaction_commitment` | `FieldElement` | A commitment to the transactions included in the block;
-|`event_count` | `Integer` | The number of events
-| `event_commitment` | `FieldElement` | A commitment to the events produced in this block
-| `l1_gas_price` | `(Integer, Integer)` | The price of L1 gas that was used while constructing this block. L1 gas prices are relevant for storage updates and L1→L2 messages (today, computation is also priced in terms of L1 gas, but this will change in the future). The price is specified in both wei and fri, hence the two numbers.
-| `l1_data_gas_price` | `(Integer, Integer)` | The price of L1 blob gas that was used while constructing this block. If the `l1_DA_MODE` of the block is set to `BLOB`, L1 blob gas prices will determine the storage update cost. The price is specified in both wei and fri, hence the two numbers.
-| `l1_da_mode` | `String` | `CALLDATA` or `BLOB`, depending on how Starknet state diffs are sent to L1
-| `protocol_version` | `Integer` | The version of the Starknet protocol used when creating this block.
+| `parent_block_hash` | `FieldElement` | The hash of the block's parent.
+|`block_number` | `Integer` | The number, that is, the height, of this block.
+| `global_state_root` | `FieldElement` | The xref:../Network_Architecture/starknet-state.adoc#state_commitment[state commitment] after the block.
+|`sequencer_address` | `ContractAddress` | The Starknet address of the sequencer that created the block.
+| `block_timestamp` | `Timestamp` | The time the sequencer created the block, before executing transactions, in seconds since the Unix epoch.
+|`transaction_count` | `Integer` | The number of transactions in the block.
+| `transaction_commitment` | `FieldElement` | A commitment to the transactions included in the block.
+
+The root of a 64-bit high binary Merkle Patricia trie. The leaf at index stem:[$i$] corresponds to stem:[$${h(transaction \space hash, signature)}$$] if the stem:[$i'th$] transaction is an `invoke` transaction and stem:[$h(0,0)$] otherwise.
+|`event_count` | `Integer` | The number of events in the block.
+| `event_commitment` | `FieldElement` | A commitment to the events produced in the block.
+
+The root of a 64-bit high binary Merkle Patricia trie. The leaf at index stem:[$i$] corresponds to the hash of the stem:[$i'th$] event.
+| `l1_gas_price` | `(Integer~wei~, Integer~fri~)` | The price of L1 gas that was used while constructing the block. L1 gas prices apply to storage updates and L1->L2 messages. As of March 2023, computation is also priced in terms of L1 gas, but this will change in the future.
+
+`Integer~wei~` is the price in wei. `Integer~fri~` is the price in fri.
+| `l1_data_gas_price` | `(Integer~wei~, Integer~fri~)` | The price of L1 blob gas that was used while constructing the block. If the `l1_DA_MODE` of the block is set to `BLOB`, L1 blob gas prices determines the storage update cost.
+
+`Integer~wei~` is the price in wei. `Integer~fri~` is the price in fri.
+| `l1_da_mode` | `String` | `CALLDATA` or `BLOB`, depending on how Starknet state diffs are sent to L1.
+| `protocol_version` | `Integer` | The version of the Starknet protocol used when creating the block.
 
 
 |===
 
-Where:
-
-
-[horizontal,labelwidth='30']
-`event_commitment`:: is the root of a 64-bit high binary Merkle Patricia tree. The leaf at index stem:[$i$] corresponds to the hash of the stem:[$i'th$] event.
-`transaction_commitment`:: is the root of a 64-bit high binary Merkle Patricia tree. The leaf at index stem:[$i$] corresponds to stem:[$${h(transaction \space hash, signature)}$$] if the stem:[$i'th$] transaction is an `invoke` transaction and stem:[$h(0,0)$] otherwise.
+// Where:
+//
+//
+// [horizontal,labelwidth='30']
+// `event_commitment`:: is the root of a 64-bit high binary Merkle Patricia trie. The leaf at index stem:[$i$] corresponds to the hash of the stem:[$i'th$] event.
+// `transaction_commitment`:: is the root of a 64-bit high binary Merkle Patricia trie. The leaf at index stem:[$i$] corresponds to stem:[$${h(transaction \space hash, signature)}$$] if the stem:[$i'th$] transaction is an `invoke` transaction and stem:[$h(0,0)$] otherwise.
 
 
 


### PR DESCRIPTION
### Description of the Changes

Updated the block header page in accordance with the latest [json-rpc version](https://github.com/starkware-libs/starknet-specs/blob/4233164155b8a279b408b9638c34db2602b5cdc0/api/starknet_api_openrpc.json#L1436)

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1187/documentation/architecture_and_concepts/Network_Architecture/header/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1187)
<!-- Reviewable:end -->
