### PR TITLE
docs: Update limits_and_triggers.adoc with new block limits

### DIFF
--- a/components/Starknet/modules/tools/pages/limits_and_triggers.adoc
+++ b/components/Starknet/modules/tools/pages/limits_and_triggers.adoc
@@ -13,9 +13,9 @@ These are subject to revisions and change on a regular basis
 [%autowidth.stretch]
 |===
 |Entity | Description | Sepolia | Goerli (deprecated) | Mainnet
-|Block time | The average time it takes for a new block to be created on the Starknet blockchain.|3 minutes |3 minutes |3 minutes
+|Block time | If no other limit closes a block, the pending block is closed.| 4 minutes |4 minutes |4 minutes
 |Block limit (Cairo steps)|Starknet enforces a limit on the number of steps that can be completed
-within each block to ensure block production times remain consistent and predictable. | 12,000,000 | 12,000,000 | 10,000,000
+within each block to ensure block production times remain consistent and predictable. | 28,000,000 | 28,000,000 | 28,000,000
 |Block limit (gas)| Certain Starknet operations, such as sending messages between L1 and L2, consume Ethereum gas. The current L1 state update
 mechanism involves an Ethereum transaction for each Starknet block.
 

--- a/components/Starknet/modules/tools/pages/limits_and_triggers.adoc
+++ b/components/Starknet/modules/tools/pages/limits_and_triggers.adoc
@@ -13,8 +13,8 @@ These are subject to revisions and change on a regular basis
 [%autowidth.stretch]
 |===
 |Entity | Description | Sepolia | Goerli (deprecated) | Mainnet
-|Block time | If no other limit closes a block, the pending block is closed.| 4 minutes |4 minutes |4 minutes
-|Block limit (Cairo steps)|Starknet enforces a limit on the number of steps that can be completed
+|Block time | The maximum amount of time within which a pending block is closed, if no other limit is met. | 4 minutes |4 minutes |4 minutes
+|Block limit (Cairo steps)| The maximum number of Cairo steps that can be completed
 within each block to ensure block production times remain consistent and predictable. | 28,000,000 | 28,000,000 | 28,000,000
 |Block limit (gas)| Certain Starknet operations, such as sending messages between L1 and L2, consume Ethereum gas. The current L1 state update
 mechanism involves an Ethereum transaction for each Starknet block.


### PR DESCRIPTION
### Description of the Changes

New block limits after increasing block size. 

### PR Preview URL

[Current limits](https://starknet-io.github.io/starknet-docs/pr-1188/documentation/tools/limits_and_triggers/)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1188)
<!-- Reviewable:end -->
