### PR TITLE
docs: Updated to remove Goerli.

### DIFF
--- a/components/Starknet/modules/ROOT/partials/snippet_important_goerli2_removed.adoc
+++ b/components/Starknet/modules/ROOT/partials/snippet_important_goerli2_removed.adoc
@@ -1,6 +1,0 @@
-[IMPORTANT]
-====
-Goerli testnet 2 is removed. Goerli testnet support will be removed April 11, 2024. Sepolia testnet replaces Goerli testnet.
-
-For more information, including bridge support for Sepolia, see link:http://eepurl.com/iK0YTE[Starknet Goerli Deprecation] in the Starknet Dev News newsletter.
-====

--- a/components/Starknet/modules/ROOT/partials/snippet_important_goerli_removed.adoc
+++ b/components/Starknet/modules/ROOT/partials/snippet_important_goerli_removed.adoc
@@ -1,0 +1,10 @@
+[IMPORTANT]
+====
+.Goerli testnet support is now removed.
+
+Originally, Goerli testnet was scheduled to be removed April 11, 2024, however, following the recent mass exit of Ethereum Goerli validators and the current inactivity of Starknet Goerli, Starknet Goerli testnet is now shut down, to avoid maintaining an inactive network.
+
+Sepolia testnet replaces Goerli testnet.
+
+For more information, including bridge support for Sepolia, see link:http://eepurl.com/iK0YTE[Starknet Goerli Deprecation] in the Starknet Dev News newsletter.
+====

--- a/components/Starknet/modules/architecture_and_concepts/pages/Accounts/universal-deployer.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Accounts/universal-deployer.adoc
@@ -12,7 +12,7 @@ For details on the motivation and the decision making process, see the https://c
 
 == UDC address
 
-The UDC address is `0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf` in Mainnet, Goerli testnet, Sepolia testnet, and starknet-devnet. This address might change in the future when it is migrated to a modern version of Cairo.
+The UDC address is `0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf` in Mainnet, Sepolia testnet, and starknet-devnet. This address might change in the future when it is migrated to a modern version of Cairo.
 
 == Interface
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transaction-life-cycle.adoc
@@ -86,11 +86,11 @@ Consumed Resources:: The resources used for the execution of the transaction up 
 
 To get a receipt, use the JSON RPC method `starknet_getTransactionReceipt`.
 
-// For example, using a node with the API Key `1234`, and the transaction hash `0xdeadbeef`, you can enter the following `curl` command to get a receipt for a transaction on Goerli testnet:
+// For example, using a node with the API Key `1234`, and the transaction hash `0xdeadbeef`, you can enter the following `curl` command to get a receipt for a transaction on Sepolia testnet:
 //
 // [source,bash]
 // ----
-// curl https://starknet-goerli.rpc_provider.io/v3/1234 \
+// curl https://starknet-sepolia.rpc_provider.io/v3/1234 \
 // -X POST \
 // -H "Content-Type: application/json" \
 // -d '{"jsonrpc":"2.0","method":"starknet_getTransactionReceipt","params":["0xdeadbeef"],"id":1}'

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
@@ -477,7 +477,6 @@ chain_id = int.from_bytes(value, byteorder="big", signed=False)
 The following constants are currently used. They correspond to the chain IDs that Starknet currently supports:
 
 * `SN_MAIN` for Starknet's main network.
-* `SN_GOERLI` for Starknet's public testnet on Goerli (Deprecated).
 * `SN_SEPOLIA` for Starknet's public testnet on Sepolia.
 
-include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
+include::ROOT:partial$snippet_important_goerli_removed.adoc[]

--- a/components/Starknet/modules/cli/pages/starkli.adoc
+++ b/components/Starknet/modules/cli/pages/starkli.adoc
@@ -31,8 +31,8 @@ You can set the environment using either a command-line option or an environment
 
 Possible values are:
 
-`alpha-goerli`:: Sets the Starknet network to testnet
-`alpha-mainnet`:: Sets the Starknet network to Mainnet
+`sepolia`:: Sets the Starknet network to testnet
+`mainnet`:: Sets the Starknet network to Mainnet
 
 .Setting the network environment using a command-line option
 
@@ -61,7 +61,7 @@ For example, to use testnet, enter the following command:
 
 [source,bash]
 ----
-$ export STARKNET_NETWORK=alpha-goerli
+$ export STARKNET_NETWORK=sepolia
 ----
 
 == Setting custom endpoints
@@ -134,7 +134,7 @@ Calls a Starknet contract without affecting the state, accepts the following arg
 
 [NOTE]
 ====
-*Block Tag*
+.Block Tag
 
 A block context can be specified via the `latest` or `pending` tags, where the former refers to the latest accepted on L2 block and the latter refers to the xref:architecture_and_concepts:Network_Architecture/transaction-life-cycle.adoc#the-pending-block[pending block].
 ====

--- a/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
+++ b/components/Starknet/modules/quick_start/pages/declare_a_smart_contract.adoc
@@ -90,14 +90,14 @@ A contract can be declared on Starknet using the following command:
 
 [source,bash]
 ----
-starkli declare target/dev/<NAME>.json --network=goerli-1 --compiler-version=2.1.0
+starkli declare target/dev/<NAME>.json --network=sepolia --compiler-version=2.1.0
 ----
 
 [NOTE]
 ====
 The `--network` flag is used to specify the network you want to use, it could also be `mainnet` for example.
 
-The `--compiler-version` flag is used to specify the version of the compiler you want to use. Starkli is currently running on version `2.1.0` and `2.0.1` of the compiler.
+The `--compiler-version` flag is used to specify the version of the compiler you want to use. Starkli is currently running on version 2.6.x of the compiler.
 ====
 
 
@@ -139,8 +139,8 @@ If you were using a provider like Infura or Alchemy, the declaration command wou
 [source,bash]
 ----
 starkli declare target/dev/contracts_Ownable.sierra.json \
-    --rpc=https://starknet-goerli.infura.io/v3/<API_KEY> \ 
-    --compiler-version=2.1.0
+    --rpc=https://starknet-sepolia.infura.io/v3/<API_KEY> \
+    --compiler-version=2.6.0
 ----
 
 == Expected result

--- a/components/Starknet/modules/quick_start/pages/deploy_a_smart_contract.adoc
+++ b/components/Starknet/modules/quick_start/pages/deploy_a_smart_contract.adoc
@@ -32,7 +32,7 @@ For our example, the constructor expects an address to assign as the owner:
 starkli deploy \
     <CLASS_HASH> \
     <CONSTRUCTOR_INPUTS> \
-    --network=goerli-1
+    --network=sepolia
 ----
 
 With the class hash and constructor inputs, the command looks like this:
@@ -42,7 +42,7 @@ With the class hash and constructor inputs, the command looks like this:
 starkli deploy \
     0x00e68b4b07aeecc72f768b1c086d9b0aadce131a40a1067ffb92d0b480cf325d \
     0x02cdAb749380950e7a7c0deFf5ea8eDD716fEb3a2952aDd4E5659655077B8510 \
-    --network=goerli-1
+    --network=sepolia
 ----
 
 == Expected result

--- a/components/Starknet/modules/quick_start/pages/interact_with_a_smart_contract.adoc
+++ b/components/Starknet/modules/quick_start/pages/interact_with_a_smart_contract.adoc
@@ -30,7 +30,7 @@ As an example you can use the `get_owner` function which doesn't expect any argu
 ----
 starkli call \
     0x014825acb37c36563d3b96c450afe363d2fdfa3cfbd618b323f95b68b55ebf7e \
-    get_owner --network=goerli-1
+    get_owner --network=sepolia
 ----
 
 This will return the address that we passed to the constructor during deployment:
@@ -54,7 +54,7 @@ starkli invoke \
     0x014825acb37c36563d3b96c450afe363d2fdfa3cfbd618b323f95b68b55ebf7e \
     transfer_ownership \
     0x011088d3cbe4289bc6750ee3a9cf35e52f4fa4e0ac9f42fb0b62e983139e135a \
-    --network=goerli-1
+    --network=sepolia
 ----
 
 After the transaction is accepted on L2, you can confirm the state transition by calling the `get_owner` function again:
@@ -64,7 +64,7 @@ After the transaction is accepted on L2, you can confirm the state transition by
 starkli call \
     0x014825acb37c36563d3b96c450afe363d2fdfa3cfbd618b323f95b68b55ebf7e \
     get_owner \
-    --network=goerli-1
+    --network=sepolia
 ----
 
 The `get_owner` function now returns the new owner address, confirming the successful ownership transfer.

--- a/components/Starknet/modules/starknet_versions/pages/deprecated.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/deprecated.adoc
@@ -3,15 +3,6 @@
 
 The features on this page are deprecated, unsupported, or removed from Starknet.
 
-// [cols="1,3"]
-// |===
-// |Status|Definition
-//
-// |Deprecated| Feature or capability that is still supported, but support will be removed in a future release of Starknet.
-// Future fixes or enhancements are unlikely. If necessary, an alternative is available.
-// |Unsupported or removed|Feature or capability that is no longer supported, and might have been removed from Starknet.
-// |===
-
 [horizontal,labelwidth="15"]
 Deprecated:: Refers to a feature or capability that is still supported, but support will be removed in a future release of Starknet.
 Future fixes or enhancements are unlikely. If necessary, an alternative is available.
@@ -24,16 +15,6 @@ Removed:: Refers to a feature or capability that has been entirely removed.
 |===
 |Name|Description
 
-| Goerli testnet
-a| Goerli testnet is deprecated and is being replaced by Sepolia testnet. Starknet started migrating to Sepolia testnet on November 15th, 2023. Goerli testnet support will be removed April 11, 2024. You should migrate to Sepolia testnet as soon as possible. For more information on the Goerli deprecation, see https://ethereum.org/nb/developers/docs/networks/#ethereum-testnets[the deprecation announcement on Ethereum's site].
-
-Full nodes, API services, SDKs, and other Starknet developer tools have started their migration to Sepolia as well. Builders are urged to migrate to Sepolia as soon as possible.
-
-[NOTE]
-====
-Sepolia's state and history are relatively small. Sepolia xref:version_notes.adoc[supports declaring classes of Cairo v0 and Cairo v2.0.0 and higher].
-====
-
 |Starknet CLI | Support for the Starknet CLI has been removed. Instead use xref:cli:starkli.adoc[Starkli].
 
 Support for Starknet CLI is removed in Starknet v0.13.0.
@@ -45,6 +26,18 @@ Support for Starknet CLI is removed in Starknet v0.13.0.
 [cols="1,3"]
 |===
 |Name|Description
+
+| Goerli testnet
+a| Goerli testnet support was removed April 2, 2024. Sepolia testnet replaces Goerli testnet.
+
+Starknet started migrating to Sepolia testnet on November 15th, 2023.  For more information on the Goerli deprecation, see https://ethereum.org/nb/developers/docs/networks/#ethereum-testnets[the deprecation announcement on Ethereum's site].
+
+Full nodes, API services, SDKs, and other Starknet developer tools have migrated to Sepolia as well.
+
+[NOTE]
+====
+Sepolia's state and history are relatively small. Sepolia xref:version_notes.adoc[supports declaring classes of CairoZero and Cairo v2.0.0 and higher].
+====
 
 | Starknet feeder gateway a| The Starknet feeder gateway, a temporary solution for querying the sequencer’s state, is being replaced by Starknet full nodes (Pathfinder, Juno, Deoxys, Papyrus) and RPC services. For more information, see xref:tools:api-services.adoc[Full nodes and API services].
 
@@ -65,7 +58,7 @@ Support for the feeder gateway queries that are not required for full nodes to s
 Queries that are required for full nodes to synchronize on the state of Starknet are still supported.
 
 For more information, see the Community Forum post link:https://community.starknet.io/t/feeder-gateway-deprecation/100233[_Feeder Gateway Deprecation_].
-| Goerli testnet 2 | Goerli testnet 2 is removed. Use Goerli testnet.
+// | Goerli testnet 2 | Goerli testnet 2 is removed. Use Goerli testnet.
 |Free L1-> L2 messaging |Previously, sending a message from L1 to L2 had an optional fee associated.
 
 From xref:starknet_versions:version_notes.adoc#version0.11.0[Starknet v0.11.0], the fee mechanism is enforced and the ability to send L1->L2 messages without the corresponding L2 fee has been removed.

--- a/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
+++ b/components/Starknet/modules/starknet_versions/pages/version_notes.adoc
@@ -8,7 +8,7 @@ The following release notes cover the ongoing version changes to Starknet. You c
 Within Starknet's deployment pipeline, there are separate and distinct networks that operate independently of each other for testing before deployment.
 
 
-include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
+include::ROOT:partial$snippet_important_goerli_removed.adoc[]
 
 .Current versions supported in each environment
 [%autowidth.stretch]
@@ -17,7 +17,7 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 
 |Mainnet|0.13.1|1.5.0|2.0.0 - 2.6
 |Sepolia Testnet|0.13.1|1.5.0|2.0.0 - 2.6
-|Goerli Testnet (deprecated)|0.13.1|1.5.0|2.0.0 - 2.6
+// |Goerli Testnet (deprecated)|0.13.1|1.5.0|2.0.0 - 2.6
 |===
 
 [id="version0.13.1"]

--- a/components/Starknet/modules/tools/pages/bridged_tokens.adoc
+++ b/components/Starknet/modules/tools/pages/bridged_tokens.adoc
@@ -5,7 +5,6 @@ The tokens that are currently bridged to Starknet are listed in the following `.
 
 [horizontal,labelwidth="20"]
 link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json[`mainnet.json`^]:: The addresses of the tokens currently bridged to Starknet Mainnet.
-link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/goerli.json[`goerli.json`^]:: The addresses of the tokens currently bridged to Starknet Goerli testnet.
 link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/sepolia.json[`sepolia.json`^]:: The addresses of the tokens currently bridged to Starknet Sepolia testnet.
 
 Each token has the following parameters:

--- a/components/Starknet/modules/tools/pages/important_addresses.adoc
+++ b/components/Starknet/modules/tools/pages/important_addresses.adoc
@@ -1,7 +1,7 @@
 [id="important_addresses"]
 = Starknet contract and sequencer addresses
 
-include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
+include::ROOT:partial$snippet_important_goerli_removed.adoc[]
 
 ==  Starknet on Mainnet
 
@@ -9,13 +9,6 @@ include::ROOT:partial$snippet_important_goerli2_removed.adoc[]
 The Starknet Core Contract:: link:https://etherscan.io/address/0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4[`0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4`^]
 Verifier address::  link:https://etherscan.io/address/0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60[`0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60`^]
 Sequencer base URL for API routing:: \https://alpha-mainnet.starknet.io
-
-== Starknet version on Goerli testnet
-
-[horizontal, labelwidth="15",role="stripes-odd"]
-The Starknet Core Contract:: link:https://goerli.etherscan.io/address/0xde29d060D45901Fb19ED6C6e959EB22d8626708e[`0xde29d060D45901Fb19ED6C6e959EB22d8626708e`^]
-Verifier address::  link:https://goerli.etherscan.io/address/0x8f97970aC5a9aa8D130d35146F5b59c4aef57963[`0x8f97970aC5a9aa8D130d35146F5b59c4aef57963`^]
-Sequencer base URL for API routing:: \https://alpha4.starknet.io
 
 == Starknet version on Sepolia testnet
 
@@ -43,4 +36,3 @@ The Starknet voting token is vSTRK. For information on vSTRK, see link:https://g
 [horizontal, labelwidth="15",role="stripes-odd"]
 Mainnet address:: link:https://starkscan.co/contract/0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f[`0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f`]
 Sepolia testnet address:: link:https://starkscan.co/contract/0x035c332b8de00874e702b4831c84b22281fb3246f714475496d74e644f35d492[`0x035c332b8de00874e702b4831c84b22281fb3246f714475496d74e644f35d492`]
-Goerli testnet address:: link:https://starkscan.co/contract/0x01a881a75bb478cedfd4d3ea19d2a4564350d78ea463a5287833526a416d5e31[`0x01a881a75bb478cedfd4d3ea19d2a4564350d78ea463a5287833526a416d5e31`]

--- a/components/Starknet/modules/tools/pages/limits_and_triggers.adoc
+++ b/components/Starknet/modules/tools/pages/limits_and_triggers.adoc
@@ -10,40 +10,40 @@ Blockifier-related constants and limits are defined, starting from Starknet vers
 These are subject to revisions and change on a regular basis
 ====
 
+include::ROOT:partial$snippet_important_goerli_removed.adoc[]
 .Starknet's current limits
 [%header, stripes=even]
 [%autowidth.stretch]
 |===
-|Entity | Description | Sepolia | Goerli (deprecated) | Mainnet
-|Block time | The maximum amount of time within which a pending block is closed, if no other limit is met. | 6 minutes |4 minutes |6 minutes
+|Entity | Description | Sepolia | Goerli support is removed | Mainnet
+|Block time | The maximum amount of time within which a pending block is closed, if no other limit is met. | 6 minutes | N/A |6 minutes
 |Block limit (Cairo steps)| The maximum number of Cairo steps that can be completed
-within each block to ensure block production times remain consistent and predictable. | 40,000,000 | 28,000,000 | 40,000,000
+within each block to ensure block production times remain consistent and predictable. | 40,000,000 | N/A | 40,000,000
 |Block limit (gas)| Certain Starknet operations, such as sending messages between L1 and L2, consume Ethereum gas. The current L1 state update
 mechanism involves an Ethereum transaction for each Starknet block.
 
 The gas limit for Starknet blocks is therefore inherited from the gas limit for Ethereum blocks.
-|5,000,000 |5,000,000 |5,000,000
+|5,000,000 | N/A |5,000,000
 
 |Max transaction size (Cairo steps)|The maximum number of computational steps, measured in Cairo steps, that a transaction can contain when processed on the Starknet network.
 This limit is important for ensuring the efficient execution of transactions and preventing potential congestion.
-| 4,000,000 | 4,000,000 | 4,000,000
+| 4,000,000 | N/A | 4,000,000
 
-|Max Cairo steps for `validate`| The maximum number of computational steps, measured in Cairo steps, for a `validate` function. | 1,000,000 | 1,000,000 |1,000,000
+|Max Cairo steps for `validate`| The maximum number of computational steps, measured in Cairo steps, for a `validate` function. | 1,000,000 | N/A |1,000,000
 
 |Max contract bytecode size (Number of felts in the program)| The maximum size of the bytecode or program that a smart contract can have on Starknet.
 
 Bytecode is the low-level code that comprises smart contracts. Limiting this size helps manage the complexity of contracts and the overall efficiency of the network.
-| 81,290 | 81,290 | 81,290
+| 81,290 | N/A | 81,290
 |Max contract class size|The maximum size for a contract class within Starknet.
 
 Contract classes are a fundamental building block for smart contracts, and limiting their size can have implications for the network's scalability and security.
 | 4,089,446 bytes
-| 4,089,446 bytes
+| N/A
 | 4,089,446 bytes
 
 |IP address limits (read/write)| In order to reduce network spam, Starknet limits the amount of contract reads and writes that a single IP
-address can make. | 200 per min per IP address| 200 per min per IP address|200 per min per IP address
-| Signature length (felts) |  | 4,000 | 4,000 | 4,000
-| Calldata length (felts)  |  | 4,000 | 4,000 | 4,000
+address can make. | 200 per min per IP address| N/A |200 per min per IP address
+| Signature length (felts) |  | 4,000 | N/A | 4,000
+| Calldata length (felts)  |  | 4,000 | N/A | 4,000
 |===
-

--- a/components/Starknet/modules/tools/pages/limits_and_triggers.adoc
+++ b/components/Starknet/modules/tools/pages/limits_and_triggers.adoc
@@ -15,35 +15,34 @@ include::ROOT:partial$snippet_important_goerli_removed.adoc[]
 [%header, stripes=even]
 [%autowidth.stretch]
 |===
-|Entity | Description | Sepolia | Goerli support is removed | Mainnet
-|Block time | The maximum amount of time within which a pending block is closed, if no other limit is met. | 6 minutes | N/A |6 minutes
+|Entity | Description | Sepolia |  Mainnet
+|Block time | The maximum amount of time within which a pending block is closed, if no other limit is met. | 6 minutes | 6 minutes
 |Block limit (Cairo steps)| The maximum number of Cairo steps that can be completed
-within each block to ensure block production times remain consistent and predictable. | 40,000,000 | N/A | 40,000,000
+within each block to ensure block production times remain consistent and predictable. | 40,000,000 |  40,000,000
 |Block limit (gas)| Certain Starknet operations, such as sending messages between L1 and L2, consume Ethereum gas. The current L1 state update
 mechanism involves an Ethereum transaction for each Starknet block.
 
 The gas limit for Starknet blocks is therefore inherited from the gas limit for Ethereum blocks.
-|5,000,000 | N/A |5,000,000
+|5,000,000 | 5,000,000
 
 |Max transaction size (Cairo steps)|The maximum number of computational steps, measured in Cairo steps, that a transaction can contain when processed on the Starknet network.
 This limit is important for ensuring the efficient execution of transactions and preventing potential congestion.
-| 4,000,000 | N/A | 4,000,000
+| 4,000,000 |  4,000,000
 
-|Max Cairo steps for `validate`| The maximum number of computational steps, measured in Cairo steps, for a `validate` function. | 1,000,000 | N/A |1,000,000
+|Max Cairo steps for `validate`| The maximum number of computational steps, measured in Cairo steps, for a `validate` function. | 1,000,000 | 1,000,000
 
 |Max contract bytecode size (Number of felts in the program)| The maximum size of the bytecode or program that a smart contract can have on Starknet.
 
 Bytecode is the low-level code that comprises smart contracts. Limiting this size helps manage the complexity of contracts and the overall efficiency of the network.
-| 81,290 | N/A | 81,290
+| 81,290 |  81,290
 |Max contract class size|The maximum size for a contract class within Starknet.
 
 Contract classes are a fundamental building block for smart contracts, and limiting their size can have implications for the network's scalability and security.
 | 4,089,446 bytes
-| N/A
 | 4,089,446 bytes
 
 |IP address limits (read/write)| In order to reduce network spam, Starknet limits the amount of contract reads and writes that a single IP
-address can make. | 200 per min per IP address| N/A |200 per min per IP address
-| Signature length (felts) |  | 4,000 | N/A | 4,000
-| Calldata length (felts)  |  | 4,000 | N/A | 4,000
+address can make. | 200 per min per IP address| 200 per min per IP address
+| Signature length (felts) |  | 4,000 |  4,000
+| Calldata length (felts)  |  | 4,000 |  4,000
 |===

--- a/components/Starknet/modules/tools/pages/starkgate-bridge.adoc
+++ b/components/Starknet/modules/tools/pages/starkgate-bridge.adoc
@@ -25,7 +25,6 @@ For a comprehensive list of tokens that StarkGate supports, see the JSON files i
 
 | Mainnet | link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json[mainnet.json]
 | Sepolia testnet | link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/sepolia.json[sepolia.json]
-| Goerli testnet (deprecated) | https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/goerli.json[goerli.json]
 |===
 
 [NOTE]

--- a/playbook.yml
+++ b/playbook.yml
@@ -41,7 +41,7 @@ asciidoc:
     # These attributes define the version footer, located in the starknet-docs-antora-ui project,
     # In /src/partials/, in the files footer-content.hbs and starknet_version.hbs.
     starknet_mainnet_version: 'Mainnet: 0.13.1'
-    starknet_testnet_version: 'Sepolia: 0.13.1 | Goerli: 0.13.1'
+    starknet_testnet_version: 'Sepolia: 0.13.1'
     page-starknet_version: '{starknet_mainnet_version} | {starknet_testnet_version}'
 
 


### PR DESCRIPTION
### Description of the Changes

Updated to remove Goerli.

Based on this announcement from yesterday, April 2, 2024:

>Following the mass exodus of Ethereum Goerli validators and the utter inactivity of Starknet Goerli over the last day, Starknet Goerli testnet will be shutting down later today to avoid maintaining an inactive network. Sepolia testnet awaits with open arms. See you there!

### PR Preview URL

**Please use the Files changed tab or Reviewable to see what has been removed.** I only included links to specific pages where it is easy to view the changes, but the site preview does not show what was changed or removed, only how the site will appear when published.

* [Current limits](https://starknet-io.github.io/starknet-docs/pr-1212/documentation/tools/limits_and_triggers/)
* Footer: 
![image](https://github.com/starknet-io/starknet-docs/assets/39279277/04859740-0dc5-48f2-9d7f-89f57fa09b8b)
* [Release notes](https://starknet-io.github.io/starknet-docs/pr-1212/documentation/starknet_versions/version_notes/)
* [Deprecated, unsupported, and removed features](https://starknet-io.github.io/starknet-docs/pr-1212/documentation/starknet_versions/deprecated/)
* [Starknet contracts and sequencer addresses](https://starknet-io.github.io/starknet-docs/pr-1212/documentation/tools/important_addresses/)
* [Bridged tokens](https://starknet-io.github.io/starknet-docs/pr-1212/documentation/tools/bridged_tokens/)


### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1212)
<!-- Reviewable:end -->
