### PR TITLE
Precise the pedersen hash construction for contract trie. 

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/starknet-state.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/starknet-state.adoc
@@ -65,7 +65,16 @@ The information stored in the leaf is as follows:
 
 [,,subs="quotes"]
 ----
-_h_~Ped~(_h_~Ped~(_h_~Ped~(class_hash, storage_root), nonce), 0)
+_h_~Ped~(
+  _h_~Ped~(
+    _h_~Ped~(
+      class_hash,
+      storage_root
+    ), 
+    nonce
+  ),
+  0
+)
 ----
 
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/starknet-state.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/starknet-state.adoc
@@ -65,12 +65,7 @@ The information stored in the leaf is as follows:
 
 [,,subs="quotes"]
 ----
-_h_~Ped~(
-    class_hash,
-    storage_root,
-    nonce,
-    0
-)
+_h_~Ped~(_h_~Ped~(_h_~Ped~(class_hash, storage_root), nonce), 0)
 ----
 
 


### PR DESCRIPTION
The leaf hash in the contract trie is not computed using the standard pedersen array hashing defined here https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/hash-functions/#pedersen_array_hash (impl here : https://github.com/starkware-libs/cairo-lang/blob/efa9648f57568aad8f8a13fbf027d2de7c63c2c0/src/starkware/cairo/common/hash_state.py#L6 )

See : https://github.com/eqlabs/pathfinder/blob/d93f50052b6b7b22072de53f0d94e1e74fbe8247/crates/merkle-tree/src/contract_state.rs#L129-L135

This is confusing and should be precised. 
Thank you

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1214)
<!-- Reviewable:end -->
