### PR TITLE
docs: Clarify how to find StarkGate bridge and token addresses in block explorers

### DIFF
--- a/components/Starknet/modules/tools/nav.adoc
+++ b/components/Starknet/modules/tools/nav.adoc
@@ -15,16 +15,16 @@
 ** xref:ref_block_explorers.adoc[Block explorers]
 ** xref:audit.adoc[Audit providers]
 
-** StarkGate bridge guide
-*** xref:starkgate-bridge.adoc[Overview]
-*** xref:starkgate_architecture.adoc[StarkGate architecture]
-*** Procedures
-**** xref:starkgate-automated_actions_with_bridging.adoc[Performing a Smart Deposit]
-**** xref:starkgate-adding_a_token.adoc[Adding a token]
-**** xref:starkgate-cancelling a deposit.adoc[Cancelling a deposit]
-**** xref:starkgate-estimating_fees.adoc[Estimating StarkGate fees]
-**** xref:dai_token_migration.adoc[Migrating DAI v0 to DAI]
-*** xref:starkgate_function_reference.adoc[StarkGate function and event reference]
+* StarkGate bridge guide
+** xref:starkgate-bridge.adoc[Overview]
+** xref:starkgate_architecture.adoc[StarkGate architecture]
+** Procedures
+*** xref:starkgate-automated_actions_with_bridging.adoc[Performing a Smart Deposit]
+*** xref:starkgate-adding_a_token.adoc[Adding a token]
+*** xref:starkgate-cancelling a deposit.adoc[Cancelling a deposit]
+*** xref:starkgate-estimating_fees.adoc[Estimating StarkGate fees]
+*** xref:dai_token_migration.adoc[Migrating DAI v0 to DAI]
+** xref:starkgate_function_reference.adoc[StarkGate function and event reference]
 
 * Important addresses
 ** xref:important_addresses.adoc[Starknet contracts and sequencer addresses]

--- a/components/Starknet/modules/tools/pages/bridged_tokens.adoc
+++ b/components/Starknet/modules/tools/pages/bridged_tokens.adoc
@@ -1,7 +1,7 @@
 [id="bridged_tokens"]
-= Bridged tokens
+= Bridged tokens and addresses
 
-The tokens that are currently bridged to Starknet are listed in the following `.json` files:
+The tokens that are currently bridged to Starknet, including their L1 and L2 addresses, are listed in the following `.json` files:
 
 [horizontal,labelwidth="20"]
 link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json[`mainnet.json`^]:: The addresses of the tokens currently bridged to Starknet Mainnet.

--- a/components/Starknet/modules/tools/pages/starkgate-bridge.adoc
+++ b/components/Starknet/modules/tools/pages/starkgate-bridge.adoc
@@ -12,14 +12,14 @@ The terms _deposit_, _transact_, and _transfer_ refer to various operations invo
 include::partial$snippet_backwards_compatibiity_note.adoc[]
 
 [#starkgate_supported_tokens]
-== Supported tokens in StarkGate
+== Supported tokens and token addresses in StarkGate
 
 StarkGate supports many tokens, including ETH, WBTC, USDC, DAI, and many more.
 
-For a comprehensive list of tokens that StarkGate supports, see the JSON files in the Starknet GitHub repository shown in the table xref:#table_StarkGate_token_addresses[].
+For a comprehensive list of tokens that StarkGate supports, including their L1 and L2 addresses, see the JSON files in the Starknet GitHub repository shown in the table xref:#table_StarkGate_token_addresses[].
 
 [#table_StarkGate_token_addresses]
-.StarkGate bridged tokens
+.StarkGate bridged tokens and their addresses
 |===
 | Network | StarkGate bridged tokens JSON file
 

--- a/components/Starknet/modules/tools/pages/starkgate-bridge.adoc
+++ b/components/Starknet/modules/tools/pages/starkgate-bridge.adoc
@@ -12,11 +12,9 @@ The terms _deposit_, _transact_, and _transfer_ refer to various operations invo
 include::partial$snippet_backwards_compatibiity_note.adoc[]
 
 [#starkgate_supported_tokens]
-== Supported tokens and token addresses in StarkGate
+== StarkGate addresses
 
-StarkGate supports many tokens, including ETH, WBTC, USDC, DAI, and many more.
-
-For a comprehensive list of tokens that StarkGate supports, including their L1 and L2 addresses, see the JSON files in the Starknet GitHub repository shown in the table xref:#table_StarkGate_token_addresses[].
+L1 and L2 addresses for StarkGate bridges and supported tokens are listed in the JSON files in the Starknet GitHub repository shown in the table xref:#table_StarkGate_token_addresses[].
 
 [#table_StarkGate_token_addresses]
 .StarkGate bridged tokens and their addresses
@@ -26,6 +24,13 @@ For a comprehensive list of tokens that StarkGate supports, including their L1 a
 | Mainnet | link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json[mainnet.json]
 | Sepolia testnet | link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/sepolia.json[sepolia.json]
 |===
+
+[#starkgate_supported_tokens]
+== Supported tokens in StarkGate
+
+StarkGate supports many tokens, including ETH, WBTC, USDC, DAI, and many more.
+
+For a comprehensive list of tokens that StarkGate supports, including their L1 and L2 addresses, see the JSON files in the Starknet GitHub repository shown in the table xref:#table_StarkGate_token_addresses[].
 
 [NOTE]
 ====


### PR DESCRIPTION
### Description of the Changes

Readers repeatedly ask for the addresses for StarkGate bridge and supported tokens. This PR clarifies how to find the json files that include that information.

### PR Preview URL

[Bridged tokens](https://starknet-io.github.io/starknet-docs/pr-1241/documentation/tools/bridged_tokens/)
[Supported tokens and token addresses in StarkGate](https://starknet-io.github.io/starknet-docs/pr-1241/documentation/tools/starkgate-bridge/#starkgate_supported_tokens)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1241)
<!-- Reviewable:end -->
