### PR TITLE
docs: add eip4844 info to the on-chain data page

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/on-chain-data.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/on-chain-data.adoc
@@ -5,7 +5,7 @@
 == Introduction
 
 
-Starknet operates as a Validity Rollup, so when consolidating a set of Layer 2 changes on Layer 1, it updates the latest proven Layer 2 state by publishing the state diffs, that is, the differences between the previous L2 state and the new L2 state, on Ethereum.
+Starknet is a Validity Rollup, which means that after consolidating and proving a set of Layer 2 changes, it updates, on L1, the latest proven L2 state. Alongside the proof, it publishes the state diff on Ethereum. The state diff is the difference between the previous and new states.
 
 Anyone monitoring Ethereum can use this data to reconstruct the current state of Starknet.
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/on-chain-data.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/on-chain-data.adoc
@@ -4,31 +4,29 @@
 [id="introduction"]
 == Introduction
 
-Starknet is a Validity Rollup, aka ZK-Rollup. 
-This means that when a bunch of L2 changes are "rolled-up" on L1, 
-updating the latest proven L2 state, the state diffs from the previous state to the new state are published on Ethereum.
 
-This data allows anyone that observes Ethereum to reconstruct the current state of Starknet.
+Starknet operates as a Validity Rollup, so when consolidating a set of Layer 2 changes on Layer 1, it updates the latest proven Layer 2 state by publishing the state diffs, that is, the differences between the previous L2 state and the new L2 state, on Ethereum.
+
+Anyone monitoring Ethereum can use this data to reconstruct the current state of Starknet.
 
 [NOTE]
 ====
-To update the Starknet state on L1, it suffices to send a valid proof along with the state-diff, without information
-on e.g. transactions and events.
+To update the Starknet state on L1, you only need to send a valid proof along with the state difference, and there is no need to include additional details, such as transactions and events.
 
-Consequently, depending on the usecase, more information may be needed to track Starknet's state.
+Therefore, depending on the use case, you might need more information to track Starknet's state.
 ====
 
-== Data availability: EIP4844, version 0.13.1 and forward
+== Data availability: EIP-4844, Starknet 0.13.1 and forward
 
-As of Starknet v0.13.1, the state-diff may be published on Ethereum either as calldata or blobdata. 
-The decision of how to publish a particular block data is at the sequencer's discretion. The switching mechanism is kept in place for extreme scenarios in which blob prices spike beyond that of calldata, allowing the Starknet sequencer to switch back to calldata.
-In normal times, blobs are always used to publish Starknet's state-diff.
+Starting with Starknet version 0.13.1, the sequencer determines whether to publish the state difference on Ethereum as calldata or blobdata. In extreme situations where blob prices significantly exceed those of calldata, the Starknet sequencer can switch to publish the state diff as calldata.
+Under normal conditions, blobs are the default method for publishing Starknet’s state differences.
 
-The state-diff format is identical to that of 0.11.0, but the data sent to Ethereum is the FFT of the original data. 
-That is, to recover Starknet's state-diff based on blobs published on-chain, one needs to first perform IFFT over the raw blob, and only then proceed with decoding according to the format described below.
-For more information, see the https://community.starknet.io/t/data-availability-with-eip4844/[community forum post].
+The format for state diffs remains the same as in version 0.11.0, but the data sent to Ethereum is a Fast Fourier Transform (FFT) of the original data. To recover Starknet’s state diff based on blobs published onchain, you must first perform an Inverse Fast Fourier Transform (IFFT) on the raw blob, and then proceed with decoding according to the format described below.
 
-For an example blob published on Ethereum by the Starknet sequencer, see the https://etherscan.io/tx/0x8a227491bc78424c2cac1b203c95cdd99ede5112d41f0e7eab26f3c8aa9c658d/[following state update transaction].
+.Additional resources
+
+* https://community.starknet.io/t/data-availability-with-eip4844/[Data availability with EIP-4844] on the Starknet Community Forum
+* https://etherscan.io/tx/0x8a227491bc78424c2cac1b203c95cdd99ede5112d41f0e7eab26f3c8aa9c658d/[An example blob published on Ethereum by the Starknet sequencer in a state update transaction]
 
 == Data availability: v0.11.0 and forward
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/on-chain-data.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/on-chain-data.adoc
@@ -4,17 +4,31 @@
 [id="introduction"]
 == Introduction
 
-In the current stage of the Alpha, Starknet operates in Validity Rollup mode, also referred to as ZK-Rollup mode. So when the onchain state update is accepted, the state diff between the previous and new state is sent as calldata to Ethereum.
+Starknet is a Validity Rollup, aka ZK-Rollup. 
+This means that when a bunch of L2 changes are "rolled-up" on L1, 
+updating the latest proven L2 state, the state diffs from the previous state to the new state are published on Ethereum.
 
 This data allows anyone that observes Ethereum to reconstruct the current state of Starknet.
 
 [NOTE]
 ====
-To update the Starknet state on L1, it suffices to send a valid proof, without information
-on the transactions or particular changes that this update caused.
+To update the Starknet state on L1, it suffices to send a valid proof along with the state-diff, without information
+on e.g. transactions and events.
 
-Consequently, more information must be provided in order to allow other parties to locally track Starknet's state.
+Consequently, depending on the usecase, more information may be needed to track Starknet's state.
 ====
+
+== Data availability: EIP4844, version 0.13.1 and forward
+
+As of Starknet v0.13.1, the state-diff may be published on Ethereum either as calldata or blobdata. 
+The decision of how to publish a particular block data is at the sequencer's discretion. The switching mechanism is kept in place for extreme scenarios in which blob prices spike beyond that of calldata, allowing the Starknet sequencer to switch back to calldata.
+In normal times, blobs are always used to publish Starknet's state-diff.
+
+The state-diff format is identical to that of 0.11.0, but the data sent to Ethereum is the FFT of the original data. 
+That is, to recover Starknet's state-diff based on blobs published on-chain, one needs to first perform IFFT over the raw blob, and only then proceed with decoding according to the format described below.
+For more information, see the https://community.starknet.io/t/data-availability-with-eip4844/[community forum post].
+
+For an example blob published on Ethereum by the Starknet sequencer, see the https://etherscan.io/tx/0x8a227491bc78424c2cac1b203c95cdd99ede5112d41f0e7eab26f3c8aa9c658d/[following state update transaction].
 
 == Data availability: v0.11.0 and forward
 

--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/on-chain-data.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/on-chain-data.adoc
@@ -5,7 +5,7 @@
 == Introduction
 
 
-Starknet is a Validity Rollup, which means that after consolidating and proving a set of Layer 2 changes, it updates, on L1, the latest proven L2 state. Alongside the proof, it publishes the state diff on Ethereum. The state diff is the difference between the previous and new states.
+Starknet is a Validity Rollup, which means that after consolidating and proving a set of Layer 2 changes, it updates, on L1, the latest proven L2 state. Alongside the proof, it publishes the state diff on L1. The state diff is the difference between the previous and new states.
 
 Anyone monitoring Ethereum can use this data to reconstruct the current state of Starknet.
 


### PR DESCRIPTION
### Description of the Changes

The on-chain data page was not updated since v0.13.1, we add a section that contains some information about blobs

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1247/documentation/architecture_and_concepts/Network_Architecture/on-chain-data/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1247)
<!-- Reviewable:end -->
