### PR TITLE
fix: admonitions

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/system-calls-cairo1.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/system-calls-cairo1.adoc
@@ -117,11 +117,11 @@ extern fn call_contract_syscall(
 Calls a given contract. This system call expects the address of the called contract, a selector for a function within that contract, and call arguments.
 
 [NOTE]
-===
+====
 An internal call can't return `Err(_)` as this is not handled by the sequencer and the Starknet OS.
 
 If `call_contract_syscall` fails, this can't be caught and will therefore result in the entire transaction being reverted.
-===
+====
 
 [discrete]
 === Arguments


### PR DESCRIPTION
### Description of the Changes

ref: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#admonitions

before:
<img width="725" alt="image" src="https://github.com/starknet-io/starknet-docs/assets/87354252/9a22a243-bce4-428c-a1e3-c4c68a9ed3a2">

after:
<img width="737" alt="image" src="https://github.com/starknet-io/starknet-docs/assets/87354252/4d3c27dc-c24d-49a7-bce9-aed3886ee58a">


### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1271/documentation/

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1271)
<!-- Reviewable:end -->
