### PR TITLE
Fix invoke tx v3 hash calculation

### DIFF
--- a/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc
@@ -76,10 +76,8 @@ invoke_v3_tx_hash = _h_(
     chain_id,
     nonce,
     data_availability_modes,
-    _h_(
-      _h_(account_deployment_data),
-      _h_(calldata)
-    )
+    _h_(account_deployment_data),
+    _h_(calldata),
     class_hash
 )
 ----


### PR DESCRIPTION
### Description of the Changes

Current invoke tx v3 hash calculation has
```
h(
      h(account_deployment_data),
      h(calldata)
    )
```
as part of the hash calculation, though the hash is calculated without the nested hash function. Just
```
h(account_deployment_data),
h(calldata)
```
### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1276/documentation/architecture_and_concepts/Network_Architecture/transactions/#v3_hash_calculation

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1276)
<!-- Reviewable:end -->
