### PR TITLE
fix: Change "cross-chain" to "cross-layer" in L1-L2 Messaging mechanism

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/messaging-mechanism.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/messaging-mechanism.adoc
@@ -1,7 +1,7 @@
 [id="messaging_mechanism"]
 = L1-L2 messaging mechanism
 
-Starknet's ability to interact with L1 is crucial. _Messaging_ is the mechanism that enables this interaction, enabling cross-layer transactions.
+Starknet's ability to interact with L1 is crucial. _Messaging_ is the mechanism that enables this interaction.
 
 For example, you can perform computations on L2 and use the result on L1.
 

--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/messaging-mechanism.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/messaging-mechanism.adoc
@@ -1,7 +1,7 @@
 [id="messaging_mechanism"]
 = L1-L2 messaging mechanism
 
-Starknet's ability to interact with L1 is crucial. _Messaging_ is the mechanism that enables this interaction, enabling cross-chain transactions.
+Starknet's ability to interact with L1 is crucial. _Messaging_ is the mechanism that enables this interaction, enabling cross-layer transactions.
 
 For example, you can perform computations on L2 and use the result on L1.
 
@@ -9,7 +9,7 @@ Bridges on Starknet use the L1-L2  messaging mechanism. Consider that you want t
 
 Be aware that the messaging mechanism is _asynchronous_ and _asymmetric_.
 
-* _Asynchronous_: Your contract code, whether Cairo or Solidity, cannot await the result of the message being sent on the other chain within your contract code's execution.
+* _Asynchronous_: Your contract code, whether Cairo or Solidity, cannot await the result of the message being sent on the other layer within your contract code's execution.
 * _Asymmetric_: Sending a message from Ethereum to Starknet, L1->L2, is fully automated by the Starknet sequencer, so the message is automatically delivered to the target contract on L2. However, when sending a message from Starknet to Ethereum, L2->L1, the sequencer only sends the hash of the message. You must then consume the message manually using a transaction on L1.
 
 [id="l2-l1_messages"]


### PR DESCRIPTION
### Description of the Changes

Topic describes L1-L2 messaging as being "cross-chain". This might be confusing, so this PR changes that to "cross-layer"

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1289)
<!-- Reviewable:end -->
