### PR TITLE
Update transaction-life-cycle.adoc with finality status of deploy_account and declare transactions

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
@@ -53,7 +53,7 @@ A rejected transaction is stored in the mempool. You cannot send another transac
 ====
 |`ACCEPTED_ON_L2` |The transaction was executed and entered an actual created block on L2.
 |`ACCEPTED_ON_L1` |The transaction was accepted on Ethereum.
-.2+|*Execution* a|`REVERTED` |The transaction passed validation but failed during execution in the sequencer. It is included in the block with the status `REVERTED`.
+.2+|*Execution* |`REVERTED` a|The transaction passed validation but failed during execution in the sequencer. It is included in the block with the status `REVERTED`.
 
 [NOTE]
 ====

--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
@@ -57,7 +57,7 @@ A rejected transaction is stored in the mempool. You cannot send another transac
 
 [NOTE]
 ====
-Since only `INVOKE` transactions have an execution phase, `DEPLOY_ACCOUNT` and `DECLARE` transactions cannot be reverted. If the `+__VALIDATE_DEPLOY__+` or `+__VALIDATE_DECLARE__+` function, respectively, fail when run in the sequencer, then the transaction will be rejected.
+Since only `INVOKE` transactions have an execution phase, `DEPLOY_ACCOUNT` and `DECLARE` transactions cannot be reverted. If either the `+__VALIDATE_DEPLOY__+` or the `+__VALIDATE_DECLARE__+` function fails when run in the sequencer, then the transaction is rejected.
 ====
 |`SUCCEEDED` |The transaction was successfully executed by the sequencer. It is included in the block.
 |===

--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
@@ -49,12 +49,16 @@ The transaction has no execution status.
 
 [NOTE]
 ====
-A `REJECTED` transaction is stored in the mempool. You cannot send another transaction with the same transaction hash.
+A rejected transaction is stored in the mempool. You cannot send another transaction with the same transaction hash.
 ====
 |`ACCEPTED_ON_L2` |The transaction was executed and entered an actual created block on L2.
 |`ACCEPTED_ON_L1` |The transaction was accepted on Ethereum.
-.2+|*Execution* |`REVERTED` |The transaction passed validation but failed during execution in the sequencer. It is included in the block with the status `REVERTED`.
-Note: Since only INVOKE transactions have an execution phase, DEPLOY_ACCOUNT and DECLARE transactions cannot be reverted. They can be `REJECTED` if `+__VALIDATE_DEPLOY__+` or `+__VALIDATE_DECLARE__+`, respectively, fail when run in the sequencer. 
+.2+|*Execution* a|`REVERTED` |The transaction passed validation but failed during execution in the sequencer. It is included in the block with the status `REVERTED`.
+
+[NOTE]
+====
+Since only `INVOKE` transactions have an execution phase, `DEPLOY_ACCOUNT` and `DECLARE` transactions cannot be reverted. They can be rejected if the `+__VALIDATE_DEPLOY__+` or `+__VALIDATE_DECLARE__+` function, respectively, fails when run in the sequencer.
+====
 |`SUCCEEDED` |The transaction was successfully executed by the sequencer. It is included in the block.
 |===
 

--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
@@ -57,7 +57,7 @@ A rejected transaction is stored in the mempool. You cannot send another transac
 
 [NOTE]
 ====
-Since only `INVOKE` transactions have an execution phase, `DEPLOY_ACCOUNT` and `DECLARE` transactions cannot be reverted. They can be rejected if the `+__VALIDATE_DEPLOY__+` or `+__VALIDATE_DECLARE__+` function, respectively, fails when run in the sequencer.
+Since only `INVOKE` transactions have an execution phase, `DEPLOY_ACCOUNT` and `DECLARE` transactions cannot be reverted. If the `+__VALIDATE_DEPLOY__+` or `+__VALIDATE_DECLARE__+` function, respectively, fail when run in the sequencer, then the transaction will be rejected.
 ====
 |`SUCCEEDED` |The transaction was successfully executed by the sequencer. It is included in the block.
 |===

--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transaction-life-cycle.adoc
@@ -54,6 +54,7 @@ A `REJECTED` transaction is stored in the mempool. You cannot send another trans
 |`ACCEPTED_ON_L2` |The transaction was executed and entered an actual created block on L2.
 |`ACCEPTED_ON_L1` |The transaction was accepted on Ethereum.
 .2+|*Execution* |`REVERTED` |The transaction passed validation but failed during execution in the sequencer. It is included in the block with the status `REVERTED`.
+Note: Since only INVOKE transactions have an execution phase, DEPLOY_ACCOUNT and DECLARE transactions cannot be reverted. They can be `REJECTED` if `+__VALIDATE_DEPLOY__+` or `+__VALIDATE_DECLARE__+`, respectively, fail when run in the sequencer. 
 |`SUCCEEDED` |The transaction was successfully executed by the sequencer. It is included in the block.
 |===
 


### PR DESCRIPTION
### Description of the Changes

DEPLOY_ACCOUNT and DECLARE transactions cannot be reverted. Added a note about this.

### PR Preview URL

[Transaction status](https://starknet-io.github.io/starknet-docs/pr-1295/architecture-and-concepts/network-architecture/transaction-life-cycle/#transaction_status)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1295)
<!-- Reviewable:end -->
