### PR TITLE
docs: Update transactions.adoc with txs v3 fee estimation

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
@@ -465,7 +465,7 @@ stem:[g_x=8747394510780077664574649897743220836492786075332494811513824810728688
 [id="v3-fee-estimation"]
 == v3 transaction fee estimation
 
-Estimate the fees of transactions with the `starknet_estimateFee` API call, which is part of the of the Starknet JSON RPC v0.7 and above. For more information see the link:https://github.com/starkware-libs/starknet-specs/blob/v0.7.1/api/starknet_api_openrpc.json#L612[Starknet API JSON RPC specification]. For information on the recommended way to translate the response fields of the call to the fields in `resource_bounds`, see link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664#sdkswallets-how-to-use-the-new-fee-estimates-7[How to use the new fee estimates?] on the Starknet community forum.
+Estimate the fees of transactions with the `starknet_estimateFee` API call, which is part of Starknet's JSON RPC v0.7.0 and above. For more information, see the link:https://github.com/starkware-libs/starknet-specs/blob/v0.7.1/api/starknet_api_openrpc.json#L612[Starknet JSON RPC specification]. For more information on how to construct the appropriate `resource_bounds` based on the response of `starknet_estimateFee`, see link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664#sdkswallets-how-to-use-the-new-fee-estimates-7[How to use the new fee estimates?] on the Starknet community forum.
 
 [id="chain-id"]
 == Chain ID

--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
@@ -462,6 +462,11 @@ The generator used in the ECDSA algorithm is stem:[G=\left(g_x, g_y\right)] wher
 
 stem:[g_x=874739451078007766457464989774322083649278607533249481151382481072868806602] stem:[g_y=152666792071518830868575557812948353041420400780739481342941381225525861407]
 
+[id="v3-fee-estimation"]
+== Transaction v3 Fee Estimation
+
+Estimating the fees of transactions v3 should be done with the `starknet_estimateFee` call of link:https://github.com/starkware-libs/starknet-specs/blob/v0.7.1/api/starknet_api_openrpc.json#L612[RPC v0.7] and above. See link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664#sdkswallets-how-to-use-the-new-fee-estimates-7[here] for the recommended way to translate the response fields of the call to the different fields of `resource_bounds`.
+
 [id="chain-id"]
 == Chain ID
 

--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
@@ -465,7 +465,7 @@ stem:[g_x=8747394510780077664574649897743220836492786075332494811513824810728688
 [id="v3-fee-estimation"]
 == v3 transaction fee estimation
 
-Estimate the fees of transactions with the `starknet_estimateFee` API call, which is part of Starknet's JSON RPC v0.7.0 and above. For more information, see the link:https://github.com/starkware-libs/starknet-specs/blob/v0.7.1/api/starknet_api_openrpc.json#L612[Starknet JSON RPC specification]. For more information on how to construct the appropriate `resource_bounds` based on the response of `starknet_estimateFee`, see link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664#sdkswallets-how-to-use-the-new-fee-estimates-7[How to use the new fee estimates?] on the Starknet community forum.
+Estimate the fees of transactions with the `starknet_estimateFee` API call, which is part of Starknet's API v0.7.0 and above. For more information, see the link:https://github.com/starkware-libs/starknet-specs/blob/v0.7.1/api/starknet_api_openrpc.json#L612[Starknet JSON RPC specification]. For more information on how to construct the appropriate `resource_bounds` based on the response of `starknet_estimateFee`, see link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664#sdkswallets-how-to-use-the-new-fee-estimates-7[How to use the new fee estimates?] on the Starknet community forum.
 
 [id="chain-id"]
 == Chain ID

--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
@@ -463,9 +463,9 @@ The generator used in the ECDSA algorithm is stem:[G=\left(g_x, g_y\right)] wher
 stem:[g_x=874739451078007766457464989774322083649278607533249481151382481072868806602] stem:[g_y=152666792071518830868575557812948353041420400780739481342941381225525861407]
 
 [id="v3-fee-estimation"]
-== Transaction v3 Fee Estimation
+== v3 transaction fee estimation
 
-Estimating the fees of transactions v3 should be done with the `starknet_estimateFee` call of link:https://github.com/starkware-libs/starknet-specs/blob/v0.7.1/api/starknet_api_openrpc.json#L612[RPC v0.7] and above. See link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664#sdkswallets-how-to-use-the-new-fee-estimates-7[here] for the recommended way to translate the response fields of the call to the different fields of `resource_bounds`.
+Estimate the fees of transactions with the `starknet_estimateFee` API call, which is part of the of the Starknet JSON RPC v0.7 and above. For more information see the link:https://github.com/starkware-libs/starknet-specs/blob/v0.7.1/api/starknet_api_openrpc.json#L612[Starknet API JSON RPC specification]. For information on the recommended way to translate the response fields of the call to the fields in `resource_bounds`, see link:https://community.starknet.io/t/starknet-v0-13-1-pre-release-notes/113664#sdkswallets-how-to-use-the-new-fee-estimates-7[How to use the new fee estimates?] on the Starknet community forum.
 
 [id="chain-id"]
 == Chain ID


### PR DESCRIPTION
### Description of the Changes

Link to the recommended way to translate the response of `starknet_estimateFee` call to the different fields of `resource_bounds` when sending txs v3.

### PR Preview URL

[Transaction v3 Fee Estimation](https://starknet-io.github.io/starknet-docs/pr-1296/architecture-and-concepts/network-architecture/transactions/#v3-fee-estimation)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1296)
<!-- Reviewable:end -->
