### PR TITLE
Fix hash calculation documentation: change 1 to 0 in v1 (deprecated) …

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
@@ -405,7 +405,7 @@ deploy_account_v1_tx_hash = _h_(
     "deploy_account",
     version,
     contract_address,
-    1,
+    0,
     _h_(class_hash, contract_address_salt, constructor_calldata),
     max_fee,
     chain_id,


### PR DESCRIPTION
# Fix hash calculation documentation for v1 (deprecated) transactions

## Description

This PR addresses the issue #1284 where the deprecated `INVOKE` v1 transaction hash calculation documentation contains a wrong field value. Specifically, the placeholder value "1" should be "0" to align with the hash computation for the different types of transactions.

## Changes Made

- Updated the `INVOKE` v1 (deprecated) transaction hash calculation documentation:
  - Changed the placeholder value from `1` to `0` in the hash calculation example.

## Affected Files

- `starknet-docs/components/Starknet/modules/architecture_and_concepts/pages/Network_Architecture/transactions.adoc`

## Verification

- Reviewed the updated documentation to ensure the placeholder value aligns with the description and other transaction types.

## Related Issue
- Closes #1284 
## Screenshot
![image](https://github.com/starknet-io/starknet-docs/assets/60315147/9238ce22-1eb9-466c-b871-eba3d9263a32)

Please review the changes and provide feedback. Thank you .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1304)
<!-- Reviewable:end -->
