### PR TITLE
feat: Remove dev survey banner; include list of contributors at the top of each page

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -21,8 +21,7 @@ content:
 
 ui:
   bundle:
-    url: https://github.com/starknet-io/starknet-docs-antora-ui/raw/dev-survey-banner/build/ui-bundle.zip
-#    url: https://github.com/starknet-io/starknet-docs-antora-ui/raw/HEAD/build/ui-bundle.zip
+    url: https://github.com/starknet-io/starknet-docs-antora-ui/raw/HEAD/build/ui-bundle.zip
     #    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
     #    url: ./ui/ui-bundle.zip
     snapshot: true


### PR DESCRIPTION
### Description of the Changes

Removing dev survey banner, and switching back to `main` branch of starknet-docs-antora-ui, which now includes the contributors at the top of each page. from https://github.com/starknet-io/starknet-docs-antora-ui/pull/39.

This feature is a response to issue #1042 *Add list of contributors*. It adds the following:
* The date and time the page was last edited, and by whom.
* A button that shows all contributors for each published page.

A big **Thank You** and shoutout to @xiaolou86 for implementing this functionality! :1st_place_medal: :tada: :man_dancing: 

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1306/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1306)
<!-- Reviewable:end -->
