### PR TITLE
fix: starknet.go name in docs

### DIFF
--- a/components/Starknet/modules/tools/pages/devtools.adoc
+++ b/components/Starknet/modules/tools/pages/devtools.adoc
@@ -83,7 +83,7 @@ JavaScript, TypeScript
 |web3-plugin-starknet |JavaScript, TypeScript |Dapps, Wallets |ChainSafe | link:https://www.npmjs.com/package/@chainsafe/web3-plugin-starknet[NPM]
 |Starknet.py |Python |Useful scripts |Software Mansion (SWM) | link:https://github.com/software-mansion/starknet.py[starknet.py Github repository]
 |Starknet-rs |Rust |Starkli, Foundry |Jonathan Lei | link:https://github.com/xJonathanLEI/starknet-rs[starknet-rs Github repository]
-|Starknet-go |Go |Chainlink |Nethermind | link:https://github.com/NethermindEth/starknet.go[starknet-go Github repository]
+|Starknet.go |Go |Chainlink |Nethermind | link:https://github.com/NethermindEth/starknet.go[starknet.go Github repository]
 |===
 
 [#starknet-devnet-rs]


### PR DESCRIPTION
### Description of the Changes

The doc says "starknet-go" but the real name is "starknet.go". This PR fixes that.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1319/

Paste here the specific URL(s) of the content that this PR addresses.
https://docs.starknet.io/tools/devtools/#sdks

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1319)
<!-- Reviewable:end -->
