### PR TITLE
Update serialization-of-cairo-types.adoc

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
@@ -189,7 +189,7 @@ Now consider instantiations of the `MessageType` enum's variants as shown in the
 |Instance |Description |Serialization
 
 |`MessageType::A` | Index=`1`. The variant's type is the unit type. | `[1]`
-|`MessageType::B(6)` a| Index=`0`. The variant's type is `u128`. | `[0,6]`
+|`MessageType::B(6)` a| Index=`0`. The variant's type is `u128`. | `[6]`
 |`MessageType::C` | Index=`2`. The variant's type is the unit type. | `[2]`
 |===
 


### PR DESCRIPTION
### Description of the Changes

The serialization description for `MessageType::B(6)` appears to be incorrect. Here's why:

1. The variant's type is `u128`, which fits entirely within a single `felt252`.
2. Therefore, it should be serialized as `[6]`, not `[0,6]`.
3. Additionally, even if it were serialize like a `u256` (which it isn't), a value of 6 would be serialized as `[6,0]`, not `[0,6]`.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [ ] Changes have been done against main branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


