### PR TITLE
fix: incorrect serialization output in serialization-of-cairo-types.adoc

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
@@ -251,7 +251,7 @@ The serialization of `MyStruct` is determined as shown in the table xref:#serial
 | [`3,1,2,3`]
 |===
 
-Combining the above, the struct is serialized as follows: `[0,2,5,3,1,2,3]`
+Combining the above, the struct is serialized as follows: `[2,0,5,3,1,2,3]`
 
 [#serialization_of_byte_arrays]
 == Serialization of byte arrays


### PR DESCRIPTION

### Description of the Changes

Bugfix: Fix an incorrect serialization output in Table 3.

The correct serialization output should be:
[2,0,5,3,1,2,3]

### PR Preview URL

https://docs.starknet.io/architecture-and-concepts/smart-contracts/serialization-of-cairo-types/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1335)
<!-- Reviewable:end -->
