### PR TITLE
Fixes wrong DEPLOY_ACCOUNT_TXN version

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
@@ -26,7 +26,7 @@ Deprecated transaction versions are still supported, but support will be removed
 
 |`INVOKE` | v3 |v1, v0 | N/A
 |`DECLARE` |v3 |v2, v1 | v0
-|`DEPLOY_ACCOUNT` | v3 | v0 | N/A
+|`DEPLOY_ACCOUNT` | v3 | v1 | N/A
 |`DEPLOY` | N/A | N/A | v0
 |===
 


### PR DESCRIPTION
### Description of the Changes

Fixes the wrong DEPLOY_ACCOUNT_TXN version in docs. There is no V0 DEPLOY_ACCOUNT_TXN, the correct one is V1.
https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json#L2226

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1339)
<!-- Reviewable:end -->
