### PR TITLE
fix: update serialization-of-cairo-types.adoc to correctly serialize u256 inside a struct

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
@@ -251,7 +251,7 @@ The serialization of `MyStruct` is determined as shown in the table xref:#serial
 | [`3,1,2,3`]
 |===
 
-Combining the above, the struct is serialized as follows: `[0,2,5,3,1,2,3]`
+Combining the above, the struct is serialized as follows: `[2,0,5,3,1,2,3]`
 
 [#serialization_of_byte_arrays]
 == Serialization of byte arrays


### PR DESCRIPTION
Fix mistake in serialization of U256 inside of a struct U256 are serialized as [low_128, high_128] as per the same documentation.

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [ ] Changes have been done against main branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1341)
<!-- Reviewable:end -->
