### PR TITLE
fix: enum variants serialization

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
@@ -141,6 +141,8 @@ An enum is serialized as follows:
 
 `<__index_of_enum_variant__>,<__serialized_variant__>`
 
+Note that enum variants indices are 0-based, not to confuse with their storage layout, which is 1-based, to distinguish the first variant from an uninitialized storage slot.
+
 .Enum serialization example 1
 
 Consider the following definition of an enum named `Week`:
@@ -162,8 +164,8 @@ Now consider instantiations of the `Week` enum's variants as shown in the table 
 |===
 |Instance |Description |Serialization
 
-|`Week::Sunday` | Index=`0`. The variant's type is the unit type. | `[1]`
-|`Week::Monday(5)` a| Index=`1`. The variant's type is `u256`.| `[2,5,0]`
+|`Week::Sunday` | Index=`0`. The variant's type is the unit type. | `[0]`
+|`Week::Monday(5)` a| Index=`1`. The variant's type is `u256`.| `[1,5,0]`
 |===
 
 .Enum serialization example 2
@@ -188,10 +190,13 @@ Now consider instantiations of the `MessageType` enum's variants as shown in the
 |===
 |Instance |Description |Serialization
 
-|`MessageType::A` | Index=`1`. The variant's type is the unit type. | `[1]`
-|`MessageType::B(6)` a| Index=`0`. The variant's type is `u128`. | `[0,6]`
+|`MessageType::A` | Index=`1`. The variant's type is the unit type. | `[0]`
+|`MessageType::B(6)` a| Index=`0`. The variant's type is `u128`. | `[1,6]`
 |`MessageType::C` | Index=`2`. The variant's type is the unit type. | `[2]`
 |===
+
+As you can see about, the `#[default]` attribute does not affect serialization. It only affects the storage layout of `MessageType`, where the default variant
+`B` will be stored as `0`.
 
 [#serialization_of_structs]
 == Serialization of structs

--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
@@ -150,12 +150,12 @@ Consider the following definition of an enum named `Week`:
 [source,cairo]
 ----
 enum Week {
-    Sunday: (), // Index=0. The variant type is the unit type.
+    Sunday: (), // Index=0. The variant type is the unit type (0-tuple).
     Monday: u256, // Index=1. The variant type is u256.
 }
 ----
 
-Now consider instantiations of the `Week` enum's variants as shown in the table xref:#serialization_of_Week[]:
+Now consider instantiations of the `Week` enum's variants as shown in the table below:
 
 [#serialization_of_Week]
 .Serialization of `Week` variants
@@ -165,7 +165,7 @@ Now consider instantiations of the `Week` enum's variants as shown in the table 
 |Instance |Description |Serialization
 
 |`Week::Sunday` | Index=`0`. The variant's type is the unit type. | `[0]`
-|`Week::Monday(5)` a| Index=`1`. The variant's type is `u256`.| `[1,5,0]`
+|`Week::Monday(5)` a| Index=`1`. The variant's type is `u256`, hence serialized to `[5,0]`, as shown in xref:#serialization_in_u256_values .| `[1,5,0]`
 |===
 
 .Enum serialization example 2
@@ -182,7 +182,7 @@ enum MessageType {
 }
 ----
 
-Now consider instantiations of the `MessageType` enum's variants as shown in the table xref:#serialization_of_MessageType[]:
+Now consider instantiations of the `MessageType` enum's variants as shown in the table below:
 
 [#serialization_of_MessageType]
 .Serialization of `MessageType` variants

--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/serialization-of-cairo-types.adoc
@@ -165,7 +165,7 @@ Now consider instantiations of the `Week` enum's variants as shown in the table 
 |Instance |Description |Serialization
 
 |`Week::Sunday` | Index=`0`. The variant's type is the unit type. | `[0]`
-|`Week::Monday(5)` a| Index=`1`. The variant's type is `u256`, hence serialized to `[5,0]`, as shown in xref:#serialization_in_u256_values .| `[1,5,0]`
+|`Week::Monday(5)` a| Index=`1`. The variant's type is `u256`, hence serialized to `[5,0]`, as shown in xref:#serialization_in_u256_values[] .| `[1,5,0]`
 |===
 
 .Enum serialization example 2


### PR DESCRIPTION
### Description of the Changes

Fixing the examples of enum serialization is the "serialization of cairo types" page. Indexing of variants for Serde is always 0-based.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1343/architecture-and-concepts/smart-contracts/serialization-of-cairo-types/#serialization_of_enums

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1343)
<!-- Reviewable:end -->
