### PR TITLE
Update declare-a-smart-contract.adoc: fix minor typo in StarkScan link change the sub-domain from `testnet` to `sepolia`.

### DIFF
--- a/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
+++ b/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
@@ -151,7 +151,7 @@ The result of the declaration command is a contract class hash:
 Class hash declared: <CLASS_HASH>
 ----
 
-This hash is the identifier of the contract class in Starknet. You can think of it as the address of the contract class. You can use a block explorer like https://testnet.starkscan.co/class/0x00e68b4b07aeecc72f768b1c086d9b0aadce131a40a1067ffb92d0b480cf325d[StarkScan] to see the contract class hash in the blockchain.
+This hash is the identifier of the contract class in Starknet. You can think of it as the address of the contract class. You can use a block explorer like https://sepolia.starkscan.co/class/0x00e68b4b07aeecc72f768b1c086d9b0aadce131a40a1067ffb92d0b480cf325d[StarkScan] to see the contract class hash in the blockchain.
 
 If the contract you are declaring has previously been declared by someone else, you will get an output like this:
 


### PR DESCRIPTION


### Description of the Changes

on line 154, I corrected the url to the StarkScan, from `https://testnet.starkscan.co` to `https://sepolia.starkscan.co`. The one with the `testnet` sub-domain is no longer working, hence, for anything `testnet` it is the `sepolia` that is working.

### PR Preview URL

[PR Preview URL](https://github.com/starknet-io/starknet-docs/compare/main...GideonBature:starknet-docs:patch-1)

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`