### PR TITLE
Removed developer tools and resources from overview

### DIFF
--- a/components/Starknet/modules/ROOT/pages/index.adoc
+++ b/components/Starknet/modules/ROOT/pages/index.adoc
@@ -41,29 +41,6 @@ specialized programming language.
 </div>
 ++++
 
-== Developer tools and resources
-
-[pass]
-++++
-<div class="no-background no-border">
-  <div class="column-container">
-    <div class="column">
-      <p><a href="https://book.starknet.io/">The Starknet Book</a></p>
-      <p><a href="https://docs.cairo-lang.org/">The Cairo docs</a></p>
-      <p><a href="https://docs.starknet.io/documentation/tools/devtools/">Starknet development tools</a></p>
-      <p><a href="https://docs.starknet.io/documentation/tools/api-services/">Full nodes and API services</a></p>
-    </div>
-    <div class="column">
-      <p><a href="https://docs.starknet.io/documentation/tools/limits_and_triggers/">Limits and triggers</a></p>
-      <p><a href="https://docs.starknet.io/documentation/cli/starkli/">Cairo 0 tools</a></p>
-      <p><a href="https://docs.starknet.io/documentation/tools/ref_block_explorers/">Block explorers</a></p>
-      <p><a href="https://docs.starknet.io/documentation/tools/indexers/">Data indexers</a></p>
-      <p><a href="https://docs.starknet.io/documentation/tools/audit/">Audit providers</a></p>
-    </div>
-  </div>
-</div>
-++++
-
 == Contribute to the Starknet docs
 
 Want to contribute to Starknet documentation? Get started here:


### PR DESCRIPTION
### Description of the Changes

Removed developer tools and resources from overview.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1378/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


