### PR TITLE
chore: replacing links to tokens lists to updated ones

### DIFF
--- a/components/Starknet/modules/starkgate/pages/overview.adoc
+++ b/components/Starknet/modules/starkgate/pages/overview.adoc
@@ -14,15 +14,15 @@ include::partial$snippet_backwards_compatibility_note.adoc[]
 [#starkgate_addresses]
 == StarkGate addresses
 
-L1 and L2 addresses for StarkGate bridges and supported tokens are listed in the JSON files in the Starknet GitHub repository shown in the table xref:#table_StarkGate_token_addresses[].
+L1 and L2 addresses for StarkGate bridges and supported tokens are listed in the JSON files shown in the table xref:#table_StarkGate_token_addresses[].
 
 [#table_StarkGate_token_addresses]
 .StarkGate bridged tokens and their addresses
 |===
 | Network | StarkGate bridged tokens JSON file
 
-| Mainnet | link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json[mainnet.json]
-| Sepolia testnet | link:https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/sepolia.json[sepolia.json]
+| Mainnet | link:https://beta.starkgate.starknet.io/static/tokens.json[mainnet.json]
+| Sepolia testnet | link:https://sepolia-beta.starkgate.starknet.io/static/tokens.json[sepolia.json]
 |===
 
 [#starkgate_supported_tokens]

--- a/components/Starknet/modules/starkgate/pages/overview.adoc
+++ b/components/Starknet/modules/starkgate/pages/overview.adoc
@@ -19,10 +19,10 @@ L1 and L2 addresses for StarkGate bridges and supported tokens are listed in the
 [#table_StarkGate_token_addresses]
 .StarkGate bridged tokens and their addresses
 |===
-| Network | StarkGate bridged tokens JSON file
+| StarkGate bridged tokens JSON files
 
-| Mainnet | link:https://beta.starkgate.starknet.io/static/tokens.json[mainnet.json]
-| Sepolia testnet | link:https://sepolia-beta.starkgate.starknet.io/static/tokens.json[sepolia.json]
+| link:https://beta.starkgate.starknet.io/static/tokens.json[Mainnet]
+| link:https://sepolia-beta.starkgate.starknet.io/static/tokens.json[Sepolia]
 |===
 
 [#starkgate_supported_tokens]
@@ -30,7 +30,7 @@ L1 and L2 addresses for StarkGate bridges and supported tokens are listed in the
 
 StarkGate supports many tokens, including ETH, WBTC, USDC, DAI, and many more.
 
-For a comprehensive list of tokens that StarkGate supports, including their L1 and L2 addresses, see the JSON files in the Starknet GitHub repository shown in the table xref:#table_StarkGate_token_addresses[].
+For a comprehensive list of tokens that StarkGate supports, including their L1 and L2 addresses, see the JSON files shown in the table xref:#table_StarkGate_token_addresses[].
 
 [NOTE]
 ====

--- a/components/Starknet/modules/starkgate/pages/overview.adoc
+++ b/components/Starknet/modules/starkgate/pages/overview.adoc
@@ -19,10 +19,10 @@ L1 and L2 addresses for StarkGate bridges and supported tokens are listed in the
 [#table_StarkGate_token_addresses]
 .StarkGate bridged tokens and their addresses
 |===
-| StarkGate bridged tokens JSON files
+| Network | StarkGate bridged tokens JSON file
 
-| link:https://beta.starkgate.starknet.io/static/tokens.json[Mainnet]
-| link:https://sepolia-beta.starkgate.starknet.io/static/tokens.json[Sepolia]
+| Mainnet | link:https://beta.starkgate.starknet.io/static/tokens.json[tokens.json]
+| Sepolia | link:https://sepolia-beta.starkgate.starknet.io/static/tokens.json[tokens.json]
 |===
 
 [#starkgate_supported_tokens]


### PR DESCRIPTION
### Description of the Changes

I updated the links to the tokens lists on mainnet and sepolia to the json files that contain all the tokens.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1381/starkgate/overview/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


