### PR TITLE
Update entering-staking.adoc

### DIFF
--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -32,7 +32,7 @@ For more information on what happens during the staking process, see xref:archit
 * In *`spender`*, enter your address.
 * In *`amount`*, enter the number of STRK tokens you want to stake. Note: STRK has 18 decimals.
 .. Submit the transaction to execute the pre-approval.
-. Using a Starknet block explorer, navigate to the Staking contract (link:https://sepolia.starkscan.co/contract/0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1[Starkscan], link:https://sepolia.voyager.online/contract/0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1[Voyager]).
+. Using a Starknet block explorer, navigate to the Staking contract (The contract addresses can be found xref:overview.adoc#contract-addresses[here]).
 . In the contract interface, locate and select the `stake` function.
 . Enter the following parameters:
 +

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -27,8 +27,8 @@ For more information on what happens during the staking process, see xref:archit
 . Pre-approve the STRK ERC20 contract for the transfer of tokens from your address to the staking contract:
 +
 * Using a Starknet block explorer, navigate to the STRK ERC20 contract (link:https://starkscan.co/token/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Starkscan], link:https://voyager.online/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Voyager]).
-* Send an 'approve' transaction to staking contract with the specified amount of STRK tokens you wish to stake. Note: STRK has 18 decimals.
-. Using a Starknet block explorer, navigate to the Staking contract. The contract addresses can be found xref:overview.adoc#contract-addresses[here].
+* Send an 'approve' transaction to the staking contract with the specified amount of STRK tokens you wish to stake (note that STRK has 18 decimals).
+. Using a Starknet block explorer, navigate to the Staking contract (the contract addresses can be found xref:overview.adoc#contract-addresses[here]).
 . In the contract interface, locate and select the `stake` function.
 . Enter the following parameters:
 +

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -26,9 +26,13 @@ For more information on what happens during the staking process, see xref:archit
 
 . Pre-approve the STRK ERC20 contract for the transfer of tokens from your address to the staking contract:
 +
-* Using a Starknet block explorer, navigate to the STRK ERC20 contract (link:https://starkscan.co/token/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Starkscan], link:https://voyager.online/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Voyager]).
-* Send an 'approve' transaction to the staking contract with the specified amount of STRK tokens you wish to stake (note that STRK has 18 decimals).
-. Using a Starknet block explorer, navigate to the Staking contract (the contract addresses can be found xref:overview.adoc#contract-addresses[here]).
+.. Using a Starknet block explorer, navigate to the STRK ERC20 contract (link:https://starkscan.co/token/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Starkscan], link:https://voyager.online/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Voyager]).
+.. In the contract interface, locate and select the `approve` function.
+.. Enter the following parameters:
+* In *`spender`*, enter your address.
+* In *`amount`*, enter the number of STRK tokens you want to stake. Note: STRK has 18 decimals.
+.. Submit the transaction to execute the pre-approval.
+. Using a Starknet block explorer, navigate to the Staking contract (link:https://sepolia.starkscan.co/contract/0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1[Starkscan], link:https://sepolia.voyager.online/contract/0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1[Voyager]).
 . In the contract interface, locate and select the `stake` function.
 . Enter the following parameters:
 +

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -15,7 +15,7 @@ For more information on what happens during the staking process, see xref:archit
 
 .Prerequisites
 
-* Validators are expected to run full nodes in preparation for the following stages of the protocol. You can use any full node implementation you choose:
+* Validators are required to run full nodes in preparation for the following stages of the protocol. You can use any full node implementation you choose:
 ** link:https://github.com/NethermindEth/juno[Juno] by Nethermind - link:https://juno.nethermind.io/hardware-requirements/#recommended-requirements[Spec].
 ** link:https://github.com/eqlabs/pathfinder[Pathfinder] by EQLabs - https://github.com/eqlabs/pathfinder?tab=readme-ov-file#hardware-requirements[Spec].
 ** link:https://github.com/madara-alliance/madara[Madara] by Madara Alliance - link:https://docs.madara.build/get-started/requirements[Spec].
@@ -24,17 +24,17 @@ For more information on what happens during the staking process, see xref:archit
 
 .Procedure
 
-. Pre-approve the STRK ERC20 contract for the transfer of tokens from your address to the staking contract (and *not* the operator contract):
+. Pre-approve the STRK ERC20 contract for the transfer of tokens from your address to the staking contract:
 +
 * Using a Starknet block explorer, navigate to the STRK ERC20 contract (link:https://starkscan.co/token/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Starkscan], link:https://voyager.online/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Voyager]).
-* Approve the staking contract to transfer the specified amount of STRK tokens on your behalf.
-. Using a Starknet block explorer, navigate to the operator contract. 
+* Send an 'approve' transaction to staking contract with the specified amount of STRK tokens you wish to stake. Note: STRK has 18 decimals.
+. Using a Starknet block explorer, navigate to the Staking contract. The contract addresses can be found xref:overview.adoc#contract-addresses[here].
 . In the contract interface, locate and select the `stake` function.
 . Enter the following parameters:
 +
 * In *`reward_address`*, enter the address where the rewards will be sent.
 * In *`operational_address`*, enter the operational address associated with this stake.
-* In *`amount`*, enter the number of STRK tokens you want to stake.
+* In *`amount`*, enter the number of STRK tokens you want to stake. Note: STRK has 18 decimals.
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.


### PR DESCRIPTION
### Description of the Changes

Got rid of the Operator contract and added some links.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1383/staking/entering-staking/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


