### PR TITLE
Staking dashboard registration links addition

### DIFF
--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -38,6 +38,10 @@ For more information on what happens during the staking process, see xref:archit
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.
+. To register your Validator on the Staking dashboards, fill out the following forms:
++
+* link:https://forms.gle/WJqrRbUwxSyG7M9x7[Voyager].
+* link:https://stakingrewards.typeform.com/to/aZdO6pW7[Staking Rewards].
 
 .Secured hardware wallets:
 Ledger hardware wallet is supported through:

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -38,10 +38,7 @@ For more information on what happens during the staking process, see xref:archit
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.
-. To register your Validator on the Staking dashboards, fill out the following forms:
-+
-* link:https://forms.gle/WJqrRbUwxSyG7M9x7[Voyager].
-* link:https://stakingrewards.typeform.com/to/aZdO6pW7[Staking Rewards].
+. Register your validator on the Staking dashboards, by link:https://forms.gle/WJqrRbUwxSyG7M9x7[whitelisting it] and link:https://stakingrewards.typeform.com/to/aZdO6pW7[claiming your staking rewards provider profile].
 
 .Secured hardware wallets:
 Ledger hardware wallet is supported through:

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -38,7 +38,7 @@ For more information on what happens during the staking process, see xref:archit
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.
-. Register your validator on the Staking dashboards, by link:https://forms.gle/WJqrRbUwxSyG7M9x7[whitelisting it] and link:https://stakingrewards.typeform.com/to/aZdO6pW7[claiming your staking rewards provider profile].
+. Register your validator on the staking dashboards, by link:https://forms.gle/WJqrRbUwxSyG7M9x7[whitelisting it] and link:https://stakingrewards.typeform.com/to/aZdO6pW7[claiming your staking rewards provider profile].
 
 .Secured hardware wallets:
 Ledger hardware wallet is supported through:


### PR DESCRIPTION
### Description of the Changes

Added Staking dashboard registration links to entering-staking.adoc.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1385/staking/entering-staking/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


