### PR TITLE
Staking operator removal (claiming-rewards.adoc)

### DIFF
--- a/components/Starknet/modules/staking/pages/claiming-rewards.adoc
+++ b/components/Starknet/modules/staking/pages/claiming-rewards.adoc
@@ -3,7 +3,7 @@
 
 :description: How to claim your staking rewards on Starknet by directly interacting with the staking or delegation pooling contracts.
 
-Staking rewards on Starknet accumulate over time as your staked STRK tokens contribute to network security. To claim these rewards, you need to interact with the Staking contract (if you are a validator) or the specific delegation pooling contract associated with the validator you have staked with (if you are a delegator) and execute the appropriate functions.
+Staking rewards on Starknet accumulate over time as your staked STRK tokens contribute to network security. To claim these rewards, you need to interact with the staking contract (if you are a validator) or the specific delegation pooling contract associated with the validator you have staked with (if you are a delegator) and execute the appropriate functions.
 
 .Prerequisites
 
@@ -14,7 +14,7 @@ Staking rewards on Starknet accumulate over time as your staked STRK tokens cont
 
 . Using a Starknet block explorer, navigate to the appropriate contract:
 + 
-* For validators: Navigate to the Staking contract.
+* For validators: Navigate to the staking contract.
 * For delegators: Navigate to the delegation pooling contract associated with the validator you have staked with.
 . In the contract interface, locate and select the `claim_rewards` function.
 . Enter the following parameters:

--- a/components/Starknet/modules/staking/pages/claiming-rewards.adoc
+++ b/components/Starknet/modules/staking/pages/claiming-rewards.adoc
@@ -3,7 +3,7 @@
 
 :description: How to claim your staking rewards on Starknet by directly interacting with the staking or delegation pooling contracts.
 
-Staking rewards on Starknet accumulate over time as your staked STRK tokens contribute to network security. To claim these rewards, you need to interact with the operator contract (if you are a validator) or the specific delegation pooling contract associated with the validator you have staked with (if you are a delegator) and execute the appropriate functions.
+Staking rewards on Starknet accumulate over time as your staked STRK tokens contribute to network security. To claim these rewards, you need to interact with the Staking contract (if you are a validator) or the specific delegation pooling contract associated with the validator you have staked with (if you are a delegator) and execute the appropriate functions.
 
 .Prerequisites
 
@@ -14,7 +14,7 @@ Staking rewards on Starknet accumulate over time as your staked STRK tokens cont
 
 . Using a Starknet block explorer, navigate to the appropriate contract:
 + 
-* For validators: Navigate to the operator contract.
+* For validators: Navigate to the Staking contract.
 * For delegators: Navigate to the delegation pooling contract associated with the validator you have staked with.
 . In the contract interface, locate and select the `claim_rewards` function.
 . Enter the following parameters:


### PR DESCRIPTION
### Description of the Changes

Got rid of operator contract in claiming-rewards.adoc.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1386/staking/claiming-rewards/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


