### PR TITLE
Stacking operator removal (managing-staking-and-delegation-operations.adoc)

### DIFF
--- a/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
+++ b/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
@@ -20,7 +20,7 @@ If a validator does not yet have a delegation pool, they can open one by calling
 
 .Procedure
 
-. Using a Starknet block explorer, navigate to the Staking contract.
+. Using a Starknet block explorer, navigate to the staking contract.
 . In the contract interface, locate and select the `set_open_for_delegation` function.
 . Enter the following parameter:
 +
@@ -35,7 +35,7 @@ Validators can update the commission rate of their delegation pool using the `up
 
 .Procedure
 
-. Using a Starknet block explorer, navigate to the Staking contract.
+. Using a Starknet block explorer, navigate to the staking contract.
 . In the contract interface, locate and select the `update_commission` function.
 . Enter the following parameter:
 +
@@ -52,7 +52,7 @@ Validators can change their operational address by interacting with the `change_
 
 .Procedure
 
-. Using a Starknet block explorer, navigate to the Staking contract.
+. Using a Starknet block explorer, navigate to the staking contract.
 . In the contract interface, locate and select the `change_operational_address` function.
 . Enter the following parameter:
 +
@@ -67,7 +67,7 @@ Both validators and delegators can update their reward address using the `change
 
 . Using a Starknet block explorer, navigate to the appropriate contract:
 +
-* For validators: Navigate to the Staking contract.
+* For validators: Navigate to the staking contract.
 * For delegators: Navigate to the delegation pooling contract.
 . In the contract interface, locate and select the `change_reward_address` function.
 . Enter the following parameter:

--- a/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
+++ b/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
@@ -20,7 +20,7 @@ If a validator does not yet have a delegation pool, they can open one by calling
 
 .Procedure
 
-. Using a Starknet block explorer, navigate to the operator contract.
+. Using a Starknet block explorer, navigate to the Staking contract.
 . In the contract interface, locate and select the `set_open_for_delegation` function.
 . Enter the following parameter:
 +
@@ -35,7 +35,7 @@ Validators can update the commission rate of their delegation pool using the `up
 
 .Procedure
 
-. Using a Starknet block explorer, navigate to the operator contract.
+. Using a Starknet block explorer, navigate to the Staking contract.
 . In the contract interface, locate and select the `update_commission` function.
 . Enter the following parameter:
 +
@@ -52,7 +52,7 @@ Validators can change their operational address by interacting with the `change_
 
 .Procedure
 
-. Using a Starknet block explorer, navigate to the operator contract.
+. Using a Starknet block explorer, navigate to the Staking contract.
 . In the contract interface, locate and select the `change_operational_address` function.
 . Enter the following parameter:
 +
@@ -67,7 +67,7 @@ Both validators and delegators can update their reward address using the `change
 
 . Using a Starknet block explorer, navigate to the appropriate contract:
 +
-* For validators: Navigate to the operator contract.
+* For validators: Navigate to the Staking contract.
 * For delegators: Navigate to the delegation pooling contract.
 . In the contract interface, locate and select the `change_reward_address` function.
 . Enter the following parameter:


### PR DESCRIPTION
### Description of the Changes

Got rid of the Operator contract in managing-staking-and-delegation-operations.adoc.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1388/staking/managing-staking-and-delegation-operations/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


