### PR TITLE
Staking operator removal (overview.adoc)

### DIFF
--- a/components/Starknet/modules/staking/pages/overview.adoc
+++ b/components/Starknet/modules/staking/pages/overview.adoc
@@ -105,7 +105,6 @@ Below are the relevant contract addresses and parameters for interacting with th
 
 * **L2:**
   - Staking address: 0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1
-  - Operator address: 0x04ce1719fd581433d59100cc3f00387c66866492253b4f3a08688828ed9f6832
   - Minting curve address: 0x0351c67dc2d4653cbe457be59a035f80ff1e6f6939118dad1b7a94317a51a454
   - Reward supplier address: 0x02ebbebb8ceb2e07f30a5088f5849afd4f908f04f3f9c97c694e5d83d2a7cc61
 


### PR DESCRIPTION
### Description of the Changes

Got rid of the Operator contract from staking/overview.adoc.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1389/staking/overview/

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`


