### PR TITLE
fix: remove starknetbook link

### DIFF
--- a/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
+++ b/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
@@ -78,7 +78,7 @@ The following are the RPC providers available for Starknet:
 |Use a provider like Infura or Alchemy.
 
 |Custom configuration
-|Set up your own node and use the RPC provider of your node. More information on this can be found within the link:https://book.starknet.io/chapter_4/node.html[Starknet Book].
+|Set up your own node and use the RPC provider of your node. More information on this can be found in the link:https://docs.starknet.io/architecture-and-concepts/nodes/[node section].
 
 |===
 

--- a/components/Starknet/modules/tools/pages/starknet-book.adoc
+++ b/components/Starknet/modules/tools/pages/starknet-book.adoc
@@ -1,7 +1,7 @@
 [id="starknet_book"]
 = About the Starknet Book
 
-The link:https://book.starknet.io[Starknet Book] serves as a comprehensive guide to understanding Starknet, Cairo, and introduces you to the Starknet ecosystem.
+The Starknet Book serves as a comprehensive guide to understanding Starknet, Cairo, and introduces you to the Starknet ecosystem.
 
 The Starknet Book caters to various objectives and interests. Mix and match these chapters to customize your learning experience based on your unique interests and requirements. Whether you're exploring smart contract development, frontend integration, or learning about the core architecture, The Starknet Book is your trusted companion on the journey of deepening your understanding of Starknet.
 


### PR DESCRIPTION
### Description of the Changes

Since the Starknet Book(https://book.starknet.io/) is no longer accessible, it is necessary to remove the links that redirect to a page that is not accessible!

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Please paste the specific URL(s) of the content that this PR addresses here.

### Check List

- [x] Changes have been done against main branch, and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`


