### PR TITLE
fix: Fix 404 for system requirement of Madara in Starknet staking guide

### DIFF
--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -18,7 +18,7 @@ For more information on what happens during the staking process, see xref:archit
 * Validators are required to run full nodes in preparation for the following stages of the protocol. You can use any full node implementation you choose:
 ** link:https://github.com/NethermindEth/juno[Juno] by Nethermind - link:https://juno.nethermind.io/hardware-requirements/#recommended-requirements[Spec].
 ** link:https://github.com/eqlabs/pathfinder[Pathfinder] by EQLabs - https://github.com/eqlabs/pathfinder?tab=readme-ov-file#hardware-requirements[Spec].
-** link:https://github.com/madara-alliance/madara[Madara] by Madara Alliance - link:https://docs.madara.build/get-started/requirements[Spec].
+** link:https://github.com/madara-alliance/madara[Madara] by Madara Alliance - link:https://docs.madara.build/Installation/requirements[Spec].
 * A Starknet-compatible block explorer or CLI tool.
 * Sufficient STRK token balance in your wallet.
 


### PR DESCRIPTION
### Description of the Changes

Fix 404 for system requirement of Madara in Starknet staking guide
This pull request includes a minor update to a document in the `components/Starknet/modules/staking/pages/entering-staking.adoc` file. The change corrects a URL in the Madara node implementation documentation link.

* Corrected the URL for the hardware requirements of the Madara node implementation in the staking documentation. (`components/Starknet/modules/staking/pages/entering-staking.adoc`)

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1404/staking/entering-staking/
![image](https://github.com/user-attachments/assets/314ade6c-b0b8-42ed-a82d-f92e4e8c84d2)
