### PR TITLE
Update declare contract quick start docs to use `scarb new`

### DIFF
--- a/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
+++ b/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
@@ -10,6 +10,7 @@ Ensure that the below commands are working properly on your system.
 ----
 starkli --version
 scarb --version
+snforge --version
 ----
 
 If either of the above commands fails, see xref:environment-setup.adoc[Setting up your environment].
@@ -21,37 +22,45 @@ Deploying a smart contract in Starknet requires two steps:
 * Declaring the class of your contract, i.e. sending your contract's code to the network.
 * Deploying a contract, i.e. creating an instance of the code you previously declared.
 
-[TIP]
-====
-If you require a smart contract for testing, you can use this sample contract, link:https://github.com/starknet-edu/starknetbook/blob/main/examples/vote-contracts/src/lib.cairo[`lib.cairo`], from the Starknet Book.
-====
 
 == Compiling a smart contract
 
-You can compile a smart contract using the Scarb compiler.
+Scarb is the preferred tool to create a new Starknet smart contract project and compile it.
 
-To compile a smart contract, create a directory containing a `Scarb.toml` file and a subdirectory named `src` containing your contract source code.
+To create a new Starknet smart contract project with Scarb, run `scarb new <project_name>`, and select the default `Starknet Foundry` as a test runner. Alternatively,  run `scarb init` in an empty directory to achieve the same result.
 
-Add the following code to the `Scarb.toml` file:
+Navigate into the newly created directory:
+[source,bash]
+----
+cd <project_name>
+----
 
+The `Scarb.toml` file should look similar to this (versions might vary):
 [source,toml]
 ----
 [package]
-name = "contracts"
+name = "my_project"
 version = "0.1.0"
+edition = "2023_11"
 
 [dependencies]
-starknet = ">=2.2.0"
+starknet = "2.8.4"
+
+[dev-dependencies]
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.32.0" }
+assert_macros = "2.8.4"
 
 [[target.starknet-contract]]
 sierra = true
 ----
 
-Navigate into the newly created directory:
-[source,bash]
-----
-cd <dir_name>
-----
+
+
+[NOTE]
+====
+Building a Starknet Foundry project with Scarb requires that a Rust toolchain is installed. You can install the Rust toolchain by running the following command: `curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh`.
+See more details on the Rust installation process at link:https://doc.rust-lang.org/beta/book/ch01-01-installation.html[Rust installation].
+====
 
 Run the following command:
 
@@ -62,27 +71,20 @@ scarb build
 
 The compiled contract will be saved in the `target/dev/` directory.
 
-The contract is now compiled and ready to be deployed. Next you will need to declare an RPC provider within your contract.
+The contract is now compiled and ready to be declared.
+
+[NOTE]
+====
+The first time the project is built, some components of Scarb are compiled locally with the Rust toolchain. This process may take a few minutes. This will not happen in subsequent builds.
+====
 
 == Setting an RPC provider
 
-To interact with the Starknet network, you need to set an RPC endpoint within Starkli.
+To interact with the Starknet network, you need to set an RPC endpoint for Starkli, as an environment variable or the flag `--rpc`. 
 
-The following are the RPC providers available for Starknet:
+The following are the RPC providers available for Starknet: xref:tools:api-services.adoc[API providers].
 
-[cols="1,2"]
-|===
-|Provider name |Description
-
-|Infura or Alchemy
-|Use a provider like Infura or Alchemy.
-
-|Custom configuration
-|Set up your own node and use the RPC provider of your node. More information on this can be found within the link:https://book.starknet.io/chapter_4/node.html[Starknet Book].
-
-|===
-
-For demonstration purposes, the Starknet Sequencer's Gateway is used in the below steps.
+For interactions with Starknet Sepolia and Starknet mainnet, Starkli supports default RPC providers when using the `--network=sepolia` or `--network=mainnet` flags (limitations to these may apply).
 
 == Declaring a smart contract
 
@@ -90,14 +92,12 @@ A contract can be declared on Starknet using the following command:
 
 [source,bash]
 ----
-starkli declare target/dev/<NAME>.json --network=sepolia --compiler-version=2.1.0
+starkli declare target/dev/<NAME>.json --network=sepolia
 ----
 
 [NOTE]
 ====
-The `--network` flag is used to specify the network you want to use, it could also be `mainnet` for example.
-
-The `--compiler-version` flag is used to specify the version of the compiler you want to use. Starkli is currently running on version 2.6.x of the compiler.
+Starkli will do its best to identify the compiler version of the declare class. In case it fails, the `--compiler-version` flag can be used to specify the version of the compiler. 
 ====
 
 
@@ -113,37 +113,39 @@ In the `--compiler-version` flag you will see possible versions of the compiler:
 [source,bash]
 ----
 --compiler-version <COMPILER_VERSION>
-          Statically-linked Sierra compiler version [possible values: 2.0.1, 2.1.0]
+          Statically-linked Sierra compiler version [possible values: ...]
 ----
 
-However, the Scarb compiler version may be `2.2.0`, you can find this out by running:
+To see the current Scarb version in use, run:
 
 [source,bash]
 ----
 scarb --version
 ----
 
-This is because Starkli and Scarb are not always in sync.
+In this case you need to use a different compiler version, switching to a different Scarb version is easy with `asdf.`
 
-In this case you would need to use the compiler version that Starkli is using by installing a previous version of Scarb. See the https://github.com/software-mansion/scarb/releases[Scarb github repo] for more detail.
-
-You can do this by running the following command for installing Scarb version `0.6.1`:
+First install the desired Scarb version:
 
 [source,bash]
 ----
-curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh -s -- -v 0.6.1
+asdf install scarb <VERSION>
 ----
 
-If you were using a provider like Infura or Alchemy, the declaration command would look like this:
+Then select it as the local version for the project:
 
 [source,bash]
 ----
-starkli declare target/dev/contracts_Ownable.sierra.json \
-    --rpc=https://starknet-sepolia.infura.io/v3/<API_KEY> \
-    --compiler-version=2.6.0
+asdf local scarb <VERSION>
 ----
+
 
 == Expected result
+
+[source,bash]
+----
+starkli declare target/dev/<NAME>.json --network=sepolia
+----
 
 The result of the declaration command is a contract class hash:
 [source,bash]
@@ -158,4 +160,13 @@ If the contract you are declaring has previously been declared by someone else, 
 [source,bash]
 ----
 Not declaring class as its already declared. Class hash: <CLASS_HASH>
+----
+
+An example of declaring a contract with a specific compiler version, and an RPC provider:
+
+[source,bash]
+----
+starkli declare target/dev/contracts_Ownable.sierra.json \
+    --rpc=https://starknet-sepolia.infura.io/v3/<API_KEY> \
+    --compiler-version=2.6.0
 ----


### PR DESCRIPTION
### Description of the Changes

The current docs on declaring a new contract are outdated and require a lot of copy and paste. Scarb comes with a subcommmand to initiate a new (and working) project that can be compiled and declared easily

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1406/quick-start/declare-a-smart-contract/

### Check List

- [X] Changes made against main branch and PR does not conflict
- [X] PR title is meaningful, e.g: `fix: minor typos in README`
- [X] Detailed description added under "Description of the Changes"
- [X] Specific URL(s) added under "PR Preview URL"


