### PR TITLE
Fixed phrasing in "Becoming a Validator"

### DIFF
--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -42,7 +42,7 @@ For more information on what happens during the staking process, see xref:archit
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.
-. Register your validator on link:https://forms.gle/WJqrRbUwxSyG7M9x7[Voyager's] and link:https://forms.gle/BUMEZx9dpd3DcdaT8[Karnot's] staking dashboards, and link:https://stakingrewards.typeform.com/to/aZdO6pW7[claim your staking rewards provider profile].
+. Register your validator on link:https://forms.gle/BUMEZx9dpd3DcdaT8[Karnot's], link:https://stakingrewards.typeform.com/to/aZdO6pW7[Staking Rewards'], and link:https://forms.gle/WJqrRbUwxSyG7M9x7[Voyager's] dashboards.
 
 .Secured hardware wallets:
 Ledger hardware wallet is supported through:


### PR DESCRIPTION
### Description of the Changes

Fixed phrasing of links to dashboards in "Becoming a Validator".

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1412/staking/entering-staking/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


