### PR TITLE
Change Argent hardware wallet setup link

### DIFF
--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -49,4 +49,4 @@ Ledger hardware wallet is supported through:
 
 * link:https://braavos.app/wallet-features/ledger-on-braavos/[Braavos wallet]
 
-* link:https://www.argent.xyz/blog/how-to-use-your-hardware-wallet-with-argent/[Argent wallet]
+* link:https://www.argent.xyz/blog/ledger-argent-integration/[Argent wallet]


### PR DESCRIPTION
### Description of the Changes

Corrected the link to Argent's HW wallet setup.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1418/staking/entering-staking/

Please paste the specific URL(s) of the content that this PR addresses here.

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


