### PR TITLE
A link change on overview.adoc

### DIFF
--- a/components/Starknet/modules/staking/pages/overview.adoc
+++ b/components/Starknet/modules/staking/pages/overview.adoc
@@ -17,9 +17,9 @@ Staking on Starknet involves locking STRK tokens in the staking protocol, contri
 * Staking on `starknet.io` (coming soon)
 * link:https://github.com/starkware-libs/starknet-staking[`starknet-staking` GitHub repository]
 * Staking dashboards:
-** link:https://www.starknetstaking.com/[Karnot]
-** link:https://www.stakingrewards.com/stake-app?input=starknet[Staking Rewards]
 ** link:https://voyager.online/staking-dashboard[Voyager]
+** link:https://www.stakingrewards.com/stake-app?input=starknet[Staking Rewards]
+** link:https://dashboard.endur.fi/[Karnot]
 
 // [NOTE]
 // ====

--- a/components/Starknet/modules/staking/pages/overview.adoc
+++ b/components/Starknet/modules/staking/pages/overview.adoc
@@ -18,7 +18,7 @@ Staking on Starknet involves locking STRK tokens in the staking protocol, contri
 * Staking dashboards:
 ** link:https://voyager.online/staking-dashboard[Voyager]
 ** link:https://www.stakingrewards.com/stake-app?input=starknet[Staking Rewards]
-** link:https://dashboard.endur.fi/[Endur.fi]
+** link:https://dashboard.endur.fi/[Endur]
 
 // [NOTE]
 // ====

--- a/components/Starknet/modules/staking/pages/overview.adoc
+++ b/components/Starknet/modules/staking/pages/overview.adoc
@@ -19,7 +19,7 @@ Staking on Starknet involves locking STRK tokens in the staking protocol, contri
 * Staking dashboards:
 ** link:https://voyager.online/staking-dashboard[Voyager]
 ** link:https://www.stakingrewards.com/stake-app?input=starknet[Staking Rewards]
-** link:https://dashboard.endur.fi/[Karnot]
+** link:https://dashboard.endur.fi/[Endur]
 
 // [NOTE]
 // ====

--- a/components/Starknet/modules/staking/pages/overview.adoc
+++ b/components/Starknet/modules/staking/pages/overview.adoc
@@ -19,7 +19,7 @@ Staking on Starknet involves locking STRK tokens in the staking protocol, contri
 * Staking dashboards:
 ** link:https://voyager.online/staking-dashboard[Voyager]
 ** link:https://www.stakingrewards.com/stake-app?input=starknet[Staking Rewards]
-** link:https://dashboard.endur.fi/[Endur]
+** link:https://dashboard.endur.fi/[Endur.fi]
 
 // [NOTE]
 // ====

--- a/components/Starknet/modules/staking/pages/overview.adoc
+++ b/components/Starknet/modules/staking/pages/overview.adoc
@@ -1,4 +1,3 @@
-
 [id="staking_overview"]
 = Staking Overview
 


### PR DESCRIPTION
### Description of the Changes

Changed the link for the Karnot dashboard on the overview page.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1420/staking/overview/#important-links

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


