### PR TITLE
Added a sepolia disclaimer on entering-staking.adoc

### DIFF
--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -26,7 +26,7 @@ For more information on what happens during the staking process, see xref:archit
 
 . Pre-approve the STRK ERC20 contract for the transfer of tokens from your address to the staking contract:
 +
-.. Using a Starknet block explorer, navigate to the STRK ERC20 contract (link:https://starkscan.co/token/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Starkscan], link:https://voyager.online/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Voyager]).
+.. Using a Starknet block explorer, navigate to the STRK ERC20 contract (On Sepolia: link:https://starkscan.co/token/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Starkscan], link:https://voyager.online/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Voyager]).
 .. In the contract interface, locate and select the `approve` function.
 .. Enter the following parameters:
 * In *`spender`*, enter the Staking contract address (The contract addresses can be found xref:overview.adoc#contract-addresses[here]).

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -26,7 +26,7 @@ For more information on what happens during the staking process, see xref:archit
 
 . Pre-approve the STRK ERC20 contract for the transfer of tokens from your address to the staking contract:
 +
-.. Using a Starknet block explorer, navigate to the STRK ERC20 contract (On Sepolia: link:https://starkscan.co/token/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Starkscan], link:https://voyager.online/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Voyager]).
+.. Using a Starknet block explorer, navigate to the STRK ERC20 contract (On Sepolia: https://sepolia.starkscan.co/token/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Starkscan], https://sepolia.voyager.online/contract/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d[Voyager]).
 .. In the contract interface, locate and select the `approve` function.
 .. Enter the following parameters:
 * In *`spender`*, enter the Staking contract address (The contract addresses can be found xref:overview.adoc#contract-addresses[here]).


### PR DESCRIPTION
### Description of the Changes

When refering to the Stark token address, I added a disclaimer describing on what chain these addresses are, Sepolia testnet.

### PR Preview URL
https://starknet-io.github.io/starknet-docs/pr-1422/staking/entering-staking/
under the procedure title.

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


