### PR TITLE
Typo fix in dapp-frameworks.adoc

### DIFF
--- a/components/Starknet/modules/tools/pages/devtools/dapp-frameworks.adoc
+++ b/components/Starknet/modules/tools/pages/devtools/dapp-frameworks.adoc
@@ -10,7 +10,7 @@ Built using NextJS, Starknet.js, Scarb, Starknet-React, Starknet Foundry and Typ
 === Relevant links
 * Website: link:https://scaffoldstark.com/[Scaffold-Stark website]
 * Docs: link:https://www.docs.scaffoldstark.com/[Scaffold-Stark Docs]
-* GitHub: link:https://github.com/Quantum3-Labs/scaffold-stark-2[Starknet Scaffold on GitHub]
+* GitHub: link:https://github.com/Quantum3-Labs/scaffold-stark-2[Scaffold-Stark on GitHub]
 
 [#starknet-scaffold]
 == Starknet Scaffold

--- a/components/Starknet/modules/tools/pages/devtools/dapp-frameworks.adoc
+++ b/components/Starknet/modules/tools/pages/devtools/dapp-frameworks.adoc
@@ -10,7 +10,7 @@ Built using NextJS, Starknet.js, Scarb, Starknet-React, Starknet Foundry and Typ
 === Relevant links
 * Website: link:https://scaffoldstark.com/[Scaffold-Stark website]
 * Docs: link:https://www.docs.scaffoldstark.com/[Scaffold-Stark Docs]
-* GitHub: link:https://github.com/Quantum3-Labs/scaffold-stark-2[starknetkit on GitHub]
+* GitHub: link:https://github.com/Quantum3-Labs/scaffold-stark-2[Starknet Scaffold on GitHub]
 
 [#starknet-scaffold]
 == Starknet Scaffold


### PR DESCRIPTION
### Description of the Changes

Fixed a typo in `dapp-frameworks.adoc`.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1423/tools/devtools/dapp-frameworks/#starknet-scaffold

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


