### PR TITLE
Clarify the usage of pool_enabled

### DIFF
--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -39,7 +39,7 @@ For more information on what happens during the staking process, see xref:archit
 * In *`reward_address`*, enter the address where the rewards will be sent.
 * In *`operational_address`*, enter the operational address associated with this stake.
 * In *`amount`*, enter the number of STRK tokens you want to stake. Note: STRK has 18 decimals.
-* In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
+* In *`pool_enabled`*, enter `0x1` (true) if you wish to enable delegation pooling, otherwise enter `0x0` (false).
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.
 . Register your validator on link:https://forms.gle/BUMEZx9dpd3DcdaT8[Karnot's], link:https://stakingrewards.typeform.com/to/aZdO6pW7[Staking Rewards'], and link:https://forms.gle/WJqrRbUwxSyG7M9x7[Voyager's] dashboards.


### PR DESCRIPTION
### Description of the Changes

Clarifying the usage of `pool_enabled` in `Becoming a Validator`:
- fixed typo in parameter name
- use integer values instead of boolean string

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Please paste the specific URL(s) of the content that this PR addresses here.

### Check List

- [X] Changes made against main branch and PR does not conflict
- [X] PR title is meaningful, e.g: `fix: minor typos in README`
- [X] Detailed description added under "Description of the Changes"
- [ ] Specific URL(s) added under "PR Preview URL"


