### PR TITLE
Added min stake info to entering-staking.adoc

### DIFF
--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -44,7 +44,7 @@ For validators who wish to use a secure hardware wallet, the https://www.ledger.
 +
 * In *`reward_address`*, enter the address where the rewards will be sent.
 * In *`operational_address`*, enter the operational address associated with this stake.
-* In *`amount`*, enter the number of STRK tokens you want to stake (note that STRK has 18 decimals). Note that the minimum is 20K STRK.
+* In *`amount`*, enter the number of STRK tokens you want to stake (note that STRK has 18 decimals and that the minimum is 20K STRK).
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -44,7 +44,7 @@ For validators who wish to use a secure hardware wallet, the https://www.ledger.
 +
 * In *`reward_address`*, enter the address where the rewards will be sent.
 * In *`operational_address`*, enter the operational address associated with this stake.
-* In *`amount`*, enter the number of STRK tokens you want to stake (note that STRK has 18 decimals).
+* In *`amount`*, enter the number of STRK tokens you want to stake (note that STRK has 18 decimals). Note that the minimum is 20K STRK.
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -36,7 +36,7 @@ For validators who wish to use a secure hardware wallet, the https://www.ledger.
 .. In the contract interface, locate and select the `approve` function.
 .. Enter the following parameters:
 * In *`spender`*, enter the xref:overview.adoc#staking_contract[staking contract's address].
-* In *`amount`*, enter the number of STRK tokens you want to stake (note the xref:overview.adoc#economic-parameters[minimum stake for validators] and that STRK has 18 decimals).
+* In *`amount`*, enter the number of STRK tokens you want to stake (note the xref:overview.adoc#economic_parameters[minimum stake for validators] and that STRK has 18 decimals).
 .. Submit the transaction to execute the pre-approval.
 . Using a Starknet block explorer such as https://starkscan.co[Starkscan] or https://voyager.online[Voyager], navigate to the staking contract by searching for xref:overview.adoc#staking_contract[its address].
 . In the contract interface, locate and select the `stake` function.
@@ -44,7 +44,7 @@ For validators who wish to use a secure hardware wallet, the https://www.ledger.
 +
 * In *`reward_address`*, enter the address where the rewards will be sent.
 * In *`operational_address`*, enter the operational address associated with this stake.
-* In *`amount`*, enter the number of STRK tokens you want to stake (note the xref:overview.adoc#economic-parameters[minimum stake for validators] and that STRK has 18 decimals).
+* In *`amount`*, enter the number of STRK tokens you want to stake (note the xref:overview.adoc#economic_parameters[minimum stake for validators] and that STRK has 18 decimals).
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -44,7 +44,7 @@ For validators who wish to use a secure hardware wallet, the https://www.ledger.
 +
 * In *`reward_address`*, enter the address where the rewards will be sent.
 * In *`operational_address`*, enter the operational address associated with this stake.
-* In *`amount`*, enter the number of STRK tokens you want to stake (note that STRK has 18 decimals and that the minimum is 20K STRK).
+* In *`amount`*, enter the number of STRK tokens you want to stake (note that STRK has 18 decimals and that the minimum amount is 20K STRK).
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.

--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -36,7 +36,7 @@ For validators who wish to use a secure hardware wallet, the https://www.ledger.
 .. In the contract interface, locate and select the `approve` function.
 .. Enter the following parameters:
 * In *`spender`*, enter the xref:overview.adoc#staking_contract[staking contract's address].
-* In *`amount`*, enter the number of STRK tokens you want to stake (note that STRK has 18 decimals).
+* In *`amount`*, enter the number of STRK tokens you want to stake (note the xref:overview.adoc#economic-parameters[minimum stake for validators] and that STRK has 18 decimals).
 .. Submit the transaction to execute the pre-approval.
 . Using a Starknet block explorer such as https://starkscan.co[Starkscan] or https://voyager.online[Voyager], navigate to the staking contract by searching for xref:overview.adoc#staking_contract[its address].
 . In the contract interface, locate and select the `stake` function.
@@ -44,7 +44,7 @@ For validators who wish to use a secure hardware wallet, the https://www.ledger.
 +
 * In *`reward_address`*, enter the address where the rewards will be sent.
 * In *`operational_address`*, enter the operational address associated with this stake.
-* In *`amount`*, enter the number of STRK tokens you want to stake (note that STRK has 18 decimals and that the minimum amount is 20K STRK).
+* In *`amount`*, enter the number of STRK tokens you want to stake (note the xref:overview.adoc#economic-parameters[minimum stake for validators] and that STRK has 18 decimals).
 * In *`pooling_enabled`*, enter `true` if you wish to enable delegation pooling, otherwise enter `false`.
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.
 . Submit the transaction to execute the staking operation.


### PR DESCRIPTION
### Description of the Changes

In the procedure, I've added the minimum amount of STRK that can be submitted.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1431/staking/entering-staking/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


