### PR TITLE
Added mainnet economical param to overview.adoc

### DIFF
--- a/components/Starknet/modules/staking/pages/overview.adoc
+++ b/components/Starknet/modules/staking/pages/overview.adoc
@@ -98,8 +98,6 @@ Stake delegators can switch between validators without waiting for the full lock
 [id="contract-addresses"]
 == Contract addresses
 
-The following are the relevant contract addresses for interacting with the staking protocol:
-
 === L1 addresses
 [horizontal, labelwidth="15"]
 
@@ -137,28 +135,18 @@ Sepolia:: 0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1
 
 == Economic parameters
 
-The following are the economic parameters used on Starknet Sepolia:
+[%autowidth]
+|===
+| Parameter | Mainnet | Sepolia
 
-==== Minimum stake for Validators
+| Minimum stake for validators | 20K STRK | 1 STRK
 
-[horizontal, labelwidth="15"]
-Mainnet:: 20K STRK
-Sepolia:: 1 STRK
+| Withdrawal security lockup | 21 days | 5 minutes
 
-==== Withdrawal Security Lockup
-
-[horizontal, labelwidth="15"]
-Mainnet:: 21 days
-Sepolia:: 5 minutes
-
-==== Minting Curve Yearly Inflation Cap (stem:[C])
-
-[horizontal, labelwidth="15"]
-Mainnet:: 1.6
-Sepolia:: 1.6
-
+| Minting curve yearly inflation cap (stem:[C]) | 1.6 | 1.6
+|===
 
 [NOTE]
 ====
-For developers who wish to do a deep dive, the index update interval parameter is also set to a minimum of 1 minute instead of the minimum of 30 minutes that will be used in production.
+For developers who wish to dive deep, the index update interval parameter is set to a minimum of 1 minute in Starkent Sepolia and 30 minutes in Starknet mainnet.
 ====

--- a/components/Starknet/modules/staking/pages/overview.adoc
+++ b/components/Starknet/modules/staking/pages/overview.adoc
@@ -135,15 +135,30 @@ Sepolia:: 0x0351c67dc2d4653cbe457be59a035f80ff1e6f6939118dad1b7a94317a51a454
 Mainnet:: 0x00ca1702e64c81d9a07b86bd2c540188d92a2c73cf5cc0e508d949015e7e84a7
 Sepolia:: 0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1
 
-== Economic parameters on Sepolia
+== Economic parameters
 
 The following are the economic parameters used on Starknet Sepolia:
 
-* Minimum STRK for Staking: 1 STRK
-* Withdrawal Security Lockup: 5 minutes
-* Minting Curve Yearly Inflation Cap (stem:[C]): 1.6
+==== Minimum stake for Validators
+
+[horizontal, labelwidth="15"]
+Mainnet:: 20K STRK
+Sepolia:: 1 STRK
+
+==== Withdrawal Security Lockup
+
+[horizontal, labelwidth="15"]
+Mainnet:: 21 days
+Sepolia:: 5 minutes
+
+==== Minting Curve Yearly Inflation Cap (stem:[C])
+
+[horizontal, labelwidth="15"]
+Mainnet:: 1.6
+Sepolia:: 1.6
+
 
 [NOTE]
 ====
-For developers who wish to deep dive, the index update interval parameter is also set to a minimum of 1 minute instead of a minimum of 24-hours which will be used in production.
+For developers who wish to do a deep dive, the index update interval parameter is also set to a minimum of 1 minute instead of the minimum of 30 minutes that will be used in production.
 ====


### PR DESCRIPTION
### Description of the Changes

Changed the structure of the economical parameter section in the overview.
Added mainnet parameters and corrected the update time from 24 hours to 30 minutes.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1432/staking/overview/#economic_parameters

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


