### PR TITLE
fix: updatec URLs for token address lists

### DIFF
--- a/components/Starknet/modules/starkgate/pages/overview.adoc
+++ b/components/Starknet/modules/starkgate/pages/overview.adoc
@@ -21,8 +21,8 @@ L1 and L2 addresses for StarkGate bridges and supported tokens are listed in the
 |===
 | Network | StarkGate bridged tokens JSON file
 
-| Mainnet | link:https://beta.starkgate.starknet.io/static/tokens.json[tokens.json]
-| Sepolia | link:https://sepolia-beta.starkgate.starknet.io/static/tokens.json[tokens.json]
+| Mainnet | link:https://starkgate.starknet.io/static/tokens.json[tokens.json]
+| Sepolia | link:https://sepolia.starkgate.starknet.io/static/tokens.json[tokens.json]
 |===
 
 [#starkgate_supported_tokens]


### PR DESCRIPTION
### Description of the Changes

I updated the URLs for token address lists (after switching the beta URL to the official URL).

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1433/starkgate/overview/ 

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


