### PR TITLE
Removed Changing the Operational Address

### DIFF
--- a/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
+++ b/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
@@ -46,18 +46,18 @@ Validators can update the commission rate of their delegation pool using the `up
 
 Both validators and delegators can update their associated addresses within their staking and delegation contracts. This section outlines how to change the operational and reward addresses.
 
-=== Changing the Operational Address (Validators)
+// === Changing the Operational Address (Validators)
+ 
+// Validators can change their operational address by interacting with the `change_operational_address` function.
 
-Validators can change their operational address by interacting with the `change_operational_address` function.
+// .Procedure
 
-.Procedure
-
-. Using a Starknet block explorer, navigate to the staking contract.
-. In the contract interface, locate and select the `change_operational_address` function.
-. Enter the following parameter:
-+
-* **`operational_address`**: Enter the new operational address.
-. Submit the transaction to update the operational address.
+// . Using a Starknet block explorer, navigate to the staking contract.
+// . In the contract interface, locate and select the `change_operational_address` function.
+// . Enter the following parameter:
+// +
+// * **`operational_address`**: Enter the new operational address.
+// . Submit the transaction to update the operational address.
 
 === Changing the Reward Address (Validators and Delegators)
 

--- a/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
+++ b/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
@@ -44,7 +44,7 @@ Validators can update the commission rate of their delegation pool using the `up
 
 == Address Management
 
-Both validators and delegators can update their associated addresses within their staking and delegation contracts. This section outlines how to change the reward addresses.
+Both validators and delegators can update their associated addresses within their staking and delegation contracts. This section outlines how to change the reward address.
 
 // === Changing the Operational Address (Validators)
  

--- a/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
+++ b/components/Starknet/modules/staking/pages/managing-staking-and-delegation-operations.adoc
@@ -44,7 +44,7 @@ Validators can update the commission rate of their delegation pool using the `up
 
 == Address Management
 
-Both validators and delegators can update their associated addresses within their staking and delegation contracts. This section outlines how to change the operational and reward addresses.
+Both validators and delegators can update their associated addresses within their staking and delegation contracts. This section outlines how to change the reward addresses.
 
 // === Changing the Operational Address (Validators)
  


### PR DESCRIPTION
### Description of the Changes

Commented out obsolete "Changing the Operational Address" in "Managing Staking and Delegation Operations". 

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1437/staking/managing-staking-and-delegation-operations/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


