### PR TITLE
operational_address explanation

### DIFF
--- a/components/Starknet/modules/staking/pages/entering-staking.adoc
+++ b/components/Starknet/modules/staking/pages/entering-staking.adoc
@@ -43,7 +43,7 @@ For validators who wish to use a secure hardware wallet, the https://www.ledger.
 . Enter the following parameters:
 +
 * In *`reward_address`*, enter the address where the rewards will be sent.
-* In *`operational_address`*, enter the operational address associated with this stake.
+* In *`operational_address`*, enter the address that xref:overview.adoc#first_stage[in the future] will be used for block attestations and sequencing.
 * In *`amount`*, enter the number of STRK tokens you want to stake (note the xref:overview.adoc#economic_parameters[minimum stake for validators] and that STRK has 18 decimals).
 * In *`pool_enabled`*, enter `1` (true) if you wish to enable delegation pooling, otherwise enter `0` (false).
 * In *`commission`*, enter the commission rate for any delegated staking. The rate should be entered as a percentage with precision, where 10000 represents 100%. For example, to set a 5% commission, you would enter 500.


### PR DESCRIPTION
### Description of the Changes

Added an explanation for `operational_address` in "Becoming a Validator".

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1439/staking/entering-staking/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


