### PR TITLE
fix: how invoke transaction v3 hash is calculated

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/network-architecture/transactions.adoc
@@ -77,11 +77,11 @@ specifically:
 invoke_v3_tx_hash = _h_(
     "invoke",
     version,
-    nonce,
     sender_address,
     _h_(tip, l1_gas_bounds, l2_gas_bounds),
     _h_(paymaster_data),
     chain_id,
+    nonce,
     data_availability_modes,
     _h_(account_deployment_data),
     _h_(calldata)


### PR DESCRIPTION
### Description of the Changes

`nonce` is not at the right place when invoke v3 transaction hash is calculated.

Close: #1459 

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1460/architecture-and-concepts/network-architecture/transactions/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


