### PR TITLE
docs: add Keccak syscall documentation

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/system-calls-cairo1.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/system-calls-cairo1.adoc
@@ -496,7 +496,7 @@ Computes the Keccak-256 hash of the input data. This system call is particularly
 [discrete]
 === Common library
 
-link:https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L89[`syscalls.cairo`^]
+link:https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L84[`syscalls.cairo`^]
 
 [discrete]
 === Example

--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/system-calls-cairo1.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/system-calls-cairo1.adoc
@@ -463,3 +463,68 @@ None.
 .Common library
 
 link:https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L70[`syscalls.cairo`^]
+
+[id="keccak"]
+== `keccak`
+
+[discrete]
+=== Function signature
+
+[source,cairo,subs="+quotes,+macros"]
+----
+extern fn keccak_syscall(
+    data: Span<felt252>
+) -> SyscallResult<u256> implicits(GasBuiltin, System) nopanic;
+----
+
+[discrete]
+=== Description
+
+Computes the Keccak-256 hash of the input data. This system call is particularly useful when interacting with Ethereum contracts or implementing Ethereum-compatible functionality, as Keccak-256 is widely used in the Ethereum ecosystem.
+
+[discrete]
+=== Arguments
+
+[horizontal,labelwidth=35]
+`_data_: Span<felt252>`:: The input data to be hashed, represented as an array of field elements.
+
+[discrete]
+=== Return values
+
+* The Keccak-256 hash of the input data as a `u256` value, wrapped in `SyscallResult`.
+
+[discrete]
+=== Common library
+
+link:https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L89[`syscalls.cairo`^]
+
+[discrete]
+=== Example
+
+The following example computes the Keccak-256 hash of an array containing two elements:
+
+[source,cairo]
+----
+use array::ArrayTrait;
+use starknet::syscalls::keccak_syscall;
+
+// Create input data
+let mut data = ArrayTrait::new();
+data.append(1);
+data.append(2);
+
+// Compute Keccak hash
+let hash = keccak_syscall(data.span()).unwrap_syscall();
+----
+
+[NOTE]
+====
+* The input data is interpreted as a sequence of bytes when computing the hash
+* The returned hash is compatible with Ethereum's Keccak-256 implementation
+* This system call is commonly used for:
+** Computing message hashes for signatures
+** Generating contract addresses
+** Implementing Ethereum-compatible hashing functionality
+====
+
+

--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/system-calls-cairo1.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/system-calls-cairo1.adoc
@@ -480,7 +480,11 @@ extern fn keccak_syscall(
 [discrete]
 === Description
 
-Computes the Keccak-256 hash of the input data. This system call is particularly useful when interacting with Ethereum contracts or implementing Ethereum-compatible functionality, as Keccak-256 is widely used in the Ethereum ecosystem.
+Computes the link:https://docs.starknet.io/architecture-and-concepts/cryptography/hash-functions/#starknet_keccak[Keccak-256 hash] of the input data.
+
+This system call is particularly useful when interacting with Ethereum contracts or implementing Ethereum-compatible functionality, as Keccak-256 is widely used in the Ethereum ecosystem.
+
+Note that instead of using this syscall directly, it is recommended to use the functions provided in link:https://github.com/starkware-libs/cairo/blob/67c6eff9c276d11bd1cc903d7a3981d8d0eb2fa2/corelib/src/keccak.cairo[`keccak.cairo`] which provide a more convenient interface and handle the syscall under the hood.
 
 [discrete]
 === Arguments
@@ -491,40 +495,28 @@ Computes the Keccak-256 hash of the input data. This system call is particularly
 [discrete]
 === Return values
 
-* The Keccak-256 hash of the input data as a `u256` value, wrapped in `SyscallResult`.
+* The Keccak-256 hash of the input data as a `u256` value.
 
 [discrete]
 === Common library
 
-link:https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L84[`syscalls.cairo`^]
+link:https://github.com/starkware-libs/cairo/blob/67c6eff9c276d11bd1cc903d7a3981d8d0eb2fa2/corelib/src/starknet/syscalls.cairo#L107[`syscalls.cairo`^]
 
 [discrete]
 === Example
 
-The following example computes the Keccak-256 hash of an array containing two elements:
+The following example demonstrates how to compute a Keccak-256 hash using the recommended functions from `keccak.cairo`:
 
 [source,cairo]
 ----
 use array::ArrayTrait;
-use starknet::syscalls::keccak_syscall;
+use keccak::keccak_u256s_le_inputs;
 
 // Create input data
 let mut data = ArrayTrait::new();
-data.append(1);
-data.append(2);
+data.append(1_u256);
+data.append(2_u256);
 
-// Compute Keccak hash
-let hash = keccak_syscall(data.span()).unwrap_syscall();
+// Compute Keccak hash using the recommended function
+let hash = keccak_u256s_le_inputs(data.span());
 ----
-
-[NOTE]
-====
-* The input data is interpreted as a sequence of bytes when computing the hash
-* The returned hash is compatible with Ethereum's Keccak-256 implementation
-* This system call is commonly used for:
-** Computing message hashes for signatures
-** Generating contract addresses
-** Implementing Ethereum-compatible hashing functionality
-====
-
-


### PR DESCRIPTION
### Description of the Changes

Added missing documentation for the Keccak system call to the System Calls section, following the established AsciiDoc format.
Related Issue:-  #1457 

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1461/architecture-and-concepts/smart-contracts/system-calls-cairo1/#keccak
 
### Check List
✅Changes made against main branch and PR does not conflict
✅PR title is meaningful
✅Detailed description added 
✅Specific URL(s) added 
