### PR TITLE
Update compiled-class-hash.adoc

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/compiled-class-hash.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/compiled-class-hash.adoc
@@ -12,7 +12,7 @@ For developers, the hash is an important part of the contract declaration proces
 
 The state commitment uses the Sierra code that results when compiling Cairo classes. Sierra acts as an intermediate representation between Cairo and Casm. Provers, however, operate solely with Casm.
 
-In order to avoid recompiling, from Sierra to Casm, each block in which the class is deployed, the state commitment gets the information it needs about the corresponding Casm from the the information contained in the compiled class hash.
+In order to avoid recompiling, from Sierra to Casm, each block in which the class is deployed, the state commitment gets the information it needs about the corresponding Casm from the information contained in the compiled class hash.
 
 When declaring a contract, the party administering the contract endorses the compiled class hash, procured using an SDK, as an integral component of the xref:network-architecture/transactions.adoc#declare_v2[`DECLARE`] transaction. Following the inclusion of the transaction in a block, the compiled class hash integrates into the state commitment.
 


### PR DESCRIPTION
### Description of the Changes

Removed redundant word at the page of  **[Compiled class hash](https://docs.starknet.io/architecture-and-concepts/smart-contracts/compiled-class-hash/)**
![image](https://github.com/user-attachments/assets/9ef0e602-14a6-431d-a9d8-76433597f949)

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1462/architecture-and-concepts/smart-contracts/compiled-class-hash/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"