### PR TITLE
fix: cairo language tags in contract-storage.adoc

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/contract-storage.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/contract-storage.adoc
@@ -11,7 +11,7 @@ The contract's storage is a persistent storage space where you can read, write, 
 
 The basic function for writing to storage writes, value to key is:
 
-[source,js]
+[source,cairo]
 ----
 storage_write_syscall(address_domain, address, value)
 ----
@@ -24,7 +24,7 @@ address is determined from the variable's name and keys.
 
 Both `storage_read` and `storage_write` are system calls that can be imported by adding the line:
 
-[source,javascript]
+[source,cairo]
 ----
 use starknet::syscalls::storage_read_syscall;
 use starknet::syscalls::storage_write_syscall;
@@ -68,5 +68,3 @@ struct Storage {
     allowances: LegacyMap::<(ContractAddress, ContractAddress), u256>,
 }
 ----
-
-


### PR DESCRIPTION
### Description of the Changes

Updated source code language tags in contract-storage.adoc to correctly identify Cairo code blocks. This change improves documentation accuracy and syntax highlighting.

This PR fixes issue (https://github.com/starknet-io/starknet-docs/issues/1463)

Changes made:
- Changed [source,js] to [source,cairo]
- Changed [source,javascript] to [source,cairo]
- No content modifications were made to preserve the original documentation

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1464/architecture-and-concepts/smart-contracts/contract-storage/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

Closes #1463

