### PR TITLE
fix: cairo-builtins escape `|`

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/cairo-builtins.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/smart-contracts/cairo-builtins.adoc
@@ -31,7 +31,7 @@ For high level Cairo keccak functions that use this builtin internally, see link
 
 |Bitwise | Computes the bitwise operations `OR`, `AND`, and `XOR` of two felts.
 
-Used internally when performing bitwise operations using the `|`, `&` and `^` operators.
+Used internally when performing bitwise operations using the `\|`, `&` and `^` operators.
 
 |EC_OP |Multiplies a point on the STARK curve by a scalar.
 |===


### PR DESCRIPTION
### Description of the Changes

Fix escape of `|` operator in cairo builtins.

Result:
<img width="649" alt="image" src="https://github.com/user-attachments/assets/bb977fad-1124-4fc5-9f2e-f27e185235b1" />

Before:
<img width="643" alt="image" src="https://github.com/user-attachments/assets/4fcd1a73-1c79-44a2-b9b5-90ef1203ac9d" />

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1467/architecture-and-concepts/smart-contracts/cairo-builtins/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


