### PR TITLE
fix: .sierra.json reference in declare-a-smart-contract.adoc

### DIFF
--- a/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
+++ b/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
@@ -92,7 +92,7 @@ A contract can be declared on Starknet using Starkli by running following comman
 
 [source,bash]
 ----
-starkli declare target/dev/<CONTRACT_NAME>.sierra.json --network=sepolia
+starkli declare target/dev/<CONTRACT_NAME>.contract_class.json --network=sepolia
 ----
 
 When using `starkli declare`, Starkli will do its best to identify the compiler version of the declared class. In case it fails, the `--compiler-version` flag can be used to specify the version of the compiler as follows:
@@ -135,7 +135,7 @@ The following is an example of declaring a contract with both a a custom RPC end
 
 [source,bash]
 ----
-starkli declare target/dev/<CONTRACT_NAME>.sierra.json \
+starkli declare target/dev/<CONTRACT_NAME>.contract_class.json \
     --rpc=https://starknet-sepolia.infura.io/v3/<API_KEY> \
     --compiler-version=2.6.0 \
 ----


### PR DESCRIPTION
### Description of the Changes

Replace old references to `<CONTRACT_NAME>.sierra.json` with the newer `<CONTRACT_NAME>.contract_class.json`. This aligns the documentation with the current `scarb build` output and helps first-time users avoid confusion when locating the file. Sierra program is embedded into `*.contract_class.json`

scarb 2.9.2 (5070ff374 2024-12-11)
cairo: 2.9.2 
sierra: 1.6.0

### PR Preview URL
https://starknet-io.github.io/starknet-docs/pr-1470/quick-start/declare-a-smart-contract/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


