### PR TITLE
fix(environment-setup): set `scarb` version first

### DIFF
--- a/components/Starknet/modules/quick-start/pages/environment-setup.adoc
+++ b/components/Starknet/modules/quick-start/pages/environment-setup.adoc
@@ -98,18 +98,18 @@ asdf plugin add scarb
 asdf install scarb latest
 ----
 
-. Restart the terminal and verify that Scarb is installed correctly:
-+
-[source, bash]
-----
-scarb --version
-----
-
 . Set a global version for Scarb (need for using `scarb init`):
 +
 [source, bash]
 ----
 asdf global scarb latest
+----
+
+. Restart the terminal and verify that Scarb is installed correctly:
++
+[source, bash]
+----
+scarb --version
 ----
 
 === Windows installation


### PR DESCRIPTION
### Description of the Changes

If you try `--version` before you tell `asdf` which version to use, you
get an error:

```
No version is set for command scarb
Consider adding one of the following versions in your config file at
scarb 2.9.2
```

This just switches the order, instructing you to `asdf global` before you `scarb --version`.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Please paste the specific URL(s) of the content that this PR addresses here.

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `fix: minor typos in README`
- [x] Detailed description added under "Description of the Changes"
- [ ] Specific URL(s) added under "PR Preview URL"