### PR TITLE
docs: Add the limit of state diff size to limits-and-triggers.adoc

### DIFF
--- a/components/Starknet/modules/tools/pages/limits-and-triggers.adoc
+++ b/components/Starknet/modules/tools/pages/limits-and-triggers.adoc
@@ -1,40 +1,76 @@
 [id="limits_and_triggers"]
+
 = Current versions and limits
+
+// Within Starknet's deployment pipeline, there are separate and distinct networks that operate independently of each other for and has its own Starknet, Cairo, and Sierra versions. Each such network also has a number of limits in place in order to keep it stable and optimized for best performance.
+
 include::ROOT:partial$snippet_important_goerli_removed.adoc[]
+
 == Current versions
+
 .Current versions supported in each Starknet environment
 [%autowidth.stretch]
 |===
 |Environment |Starknet version|Sierra version|Cairo version
+
 |Mainnet|0.13.3|1.6.0|2.0.0 - 2.8.2
 |Sepolia Testnet|0.13.3|1.6.0|2.0.0 - 2.8.2
 |===
+
 == Current limits
+
 [NOTE]
 ====
 The following limits are subject to revisions and change on a regular basis
 ====
+
 [NOTE]
 ====
 Blockifier-related constants and limits are defined, for each Starknet version starting from v0.13.0, in a JSON file called `versioned_constants` in this link:https://github.com/starkware-libs/sequencer/tree/main/crates/blockifier/resources[directory].
 ====
+
 .Starknet's current limits
 [%header]
 [%autowidth.stretch]
 |===
 |Entity | Description | Sepolia |  Mainnet
+
 |Block time | The maximum amount of time within which a pending block is closed, if no other limit is met. | 30 seconds | 30 seconds
-|Block limit (Cairo steps)| The maximum number of Cairo steps that can be completed within each block to ensure block production times remain consistent and predictable. | 40,000,000 |  40,000,000
-|Block limit (gas)| Certain Starknet operations, such as sending messages between L1 and L2, consume Ethereum gas. The current L1 state update mechanism involves an Ethereum transaction for each Starknet block. The gas limit for Starknet blocks is therefore inherited from the gas limit for Ethereum blocks. |5,000,000 | 5,000,000
-|Max transaction size (Cairo steps)|The maximum number of computational steps, measured in Cairo steps, that a transaction can contain when processed on the Starknet network. This limit is important for ensuring the efficient execution of transactions and preventing potential congestion. | 10,000,000 |  10,000,000
-|Max number of events per transaction|The maximum number of events that a transaction can emit during its execution. | 1,000 |  1,000
-|Max number of data felts per event|The maximum number of felts that an event can contain in its `data` array. | 300 |  300
-|Max number of key felts per event|The maximum number of felts that an event can contain in its `keys` array. | 50 |  50
+|Block limit (Cairo steps)| The maximum number of Cairo steps that can be completed
+within each block to ensure block production times remain consistent and predictable. | 40,000,000 |  40,000,000
+|Block limit (gas)| Certain Starknet operations, such as sending messages between L1 and L2, consume Ethereum gas. The current L1 state update
+mechanism involves an Ethereum transaction for each Starknet block.
+
+The gas limit for Starknet blocks is therefore inherited from the gas limit for Ethereum blocks.
+|5,000,000 | 5,000,000
+
+|Max transaction size (Cairo steps)|The maximum number of computational steps, measured in Cairo steps, that a transaction can contain when processed on the Starknet network.
+This limit is important for ensuring the efficient execution of transactions and preventing potential congestion.
+| 10,000,000 |  10,000,000
+
+|Max number of events per transaction|The maximum number of events that a transaction can emit during its execution.
+| 1,000 |  1,000
+
+|Max number of data felts per event|The maximum number of felts that an event can contain in its `data` array.
+| 300 |  300
+
+|Max number of key felts per event|The maximum number of felts that an event can contain in its `keys` array.
+| 50 |  50
+
 |Max Cairo steps for `validate`| The maximum number of computational steps, measured in Cairo steps, for a `validate` function. | 1,000,000 | 1,000,000
-|Max contract bytecode size (Number of felts in the program)| The maximum size of the bytecode or program that a smart contract can have on Starknet. Bytecode is the low-level code that comprises smart contracts. Limiting this size helps manage the complexity of contracts and the overall efficiency of the network. | 81,290 |  81,290
-|Max contract class size|The maximum size for a contract class within Starknet. Contract classes are a fundamental building block for smart contracts, and limiting their size can have implications for the network's scalability and security. | 4,089,446 bytes | 4,089,446 bytes
-|IP address limits (read/write)| In order to reduce network spam, Starknet limits the amount of contract reads and writes that a single IP address can make. | 200 per min per IP address| 200 per min per IP address
-|Signature length (felts) |  | 4,000 |  4,000
-|Calldata length (felts)  |  | 4,000 |  4,000
-|Max state diffs per transaction| The maximum number of storage updates (state differences) that a single transaction can generate. This limit helps maintain network stability and predictable performance. | 4,000 | 4,000
+
+|Max contract bytecode size (Number of felts in the program)| The maximum size of the bytecode or program that a smart contract can have on Starknet.
+
+Bytecode is the low-level code that comprises smart contracts. Limiting this size helps manage the complexity of contracts and the overall efficiency of the network.
+| 81,290 |  81,290
+|Max contract class size|The maximum size for a contract class within Starknet.
+
+Contract classes are a fundamental building block for smart contracts, and limiting their size can have implications for the network's scalability and security.
+| 4,089,446 bytes
+| 4,089,446 bytes
+
+|IP address limits (read/write)| In order to reduce network spam, Starknet limits the amount of contract reads and writes that a single IP
+address can make. | 200 per min per IP address| 200 per min per IP address
+| Signature length (felts) |  | 4,000 |  4,000
+| Calldata length (felts)  |  | 4,000 |  4,000
 |===

--- a/components/Starknet/modules/tools/pages/limits-and-triggers.adoc
+++ b/components/Starknet/modules/tools/pages/limits-and-triggers.adoc
@@ -48,6 +48,10 @@ The gas limit for Starknet blocks is therefore inherited from the gas limit for 
 This limit is important for ensuring the efficient execution of transactions and preventing potential congestion.
 | 10,000,000 |  10,000,000
 
+|Max state diffs per transaction|The maximum number of storage updates (state differences) that a single transaction can generate.
+This limit helps maintain network stability and predictable performance.
+| 4,000 | 4,000
+
 |Max number of events per transaction|The maximum number of events that a transaction can emit during its execution.
 | 1,000 |  1,000
 

--- a/components/Starknet/modules/tools/pages/limits-and-triggers.adoc
+++ b/components/Starknet/modules/tools/pages/limits-and-triggers.adoc
@@ -1,76 +1,40 @@
 [id="limits_and_triggers"]
-
 = Current versions and limits
-
-// Within Starknet's deployment pipeline, there are separate and distinct networks that operate independently of each other for and has its own Starknet, Cairo, and Sierra versions. Each such network also has a number of limits in place in order to keep it stable and optimized for best performance.
-
 include::ROOT:partial$snippet_important_goerli_removed.adoc[]
-
 == Current versions
-
 .Current versions supported in each Starknet environment
 [%autowidth.stretch]
 |===
 |Environment |Starknet version|Sierra version|Cairo version
-
 |Mainnet|0.13.3|1.6.0|2.0.0 - 2.8.2
 |Sepolia Testnet|0.13.3|1.6.0|2.0.0 - 2.8.2
 |===
-
 == Current limits
-
 [NOTE]
 ====
 The following limits are subject to revisions and change on a regular basis
 ====
-
 [NOTE]
 ====
 Blockifier-related constants and limits are defined, for each Starknet version starting from v0.13.0, in a JSON file called `versioned_constants` in this link:https://github.com/starkware-libs/sequencer/tree/main/crates/blockifier/resources[directory].
 ====
-
 .Starknet's current limits
 [%header]
 [%autowidth.stretch]
 |===
 |Entity | Description | Sepolia |  Mainnet
-
 |Block time | The maximum amount of time within which a pending block is closed, if no other limit is met. | 30 seconds | 30 seconds
-|Block limit (Cairo steps)| The maximum number of Cairo steps that can be completed
-within each block to ensure block production times remain consistent and predictable. | 40,000,000 |  40,000,000
-|Block limit (gas)| Certain Starknet operations, such as sending messages between L1 and L2, consume Ethereum gas. The current L1 state update
-mechanism involves an Ethereum transaction for each Starknet block.
-
-The gas limit for Starknet blocks is therefore inherited from the gas limit for Ethereum blocks.
-|5,000,000 | 5,000,000
-
-|Max transaction size (Cairo steps)|The maximum number of computational steps, measured in Cairo steps, that a transaction can contain when processed on the Starknet network.
-This limit is important for ensuring the efficient execution of transactions and preventing potential congestion.
-| 10,000,000 |  10,000,000
-
-|Max number of events per transaction|The maximum number of events that a transaction can emit during its execution.
-| 1,000 |  1,000
-
-|Max number of data felts per event|The maximum number of felts that an event can contain in its `data` array.
-| 300 |  300
-
-|Max number of key felts per event|The maximum number of felts that an event can contain in its `keys` array.
-| 50 |  50
-
+|Block limit (Cairo steps)| The maximum number of Cairo steps that can be completed within each block to ensure block production times remain consistent and predictable. | 40,000,000 |  40,000,000
+|Block limit (gas)| Certain Starknet operations, such as sending messages between L1 and L2, consume Ethereum gas. The current L1 state update mechanism involves an Ethereum transaction for each Starknet block. The gas limit for Starknet blocks is therefore inherited from the gas limit for Ethereum blocks. |5,000,000 | 5,000,000
+|Max transaction size (Cairo steps)|The maximum number of computational steps, measured in Cairo steps, that a transaction can contain when processed on the Starknet network. This limit is important for ensuring the efficient execution of transactions and preventing potential congestion. | 10,000,000 |  10,000,000
+|Max number of events per transaction|The maximum number of events that a transaction can emit during its execution. | 1,000 |  1,000
+|Max number of data felts per event|The maximum number of felts that an event can contain in its `data` array. | 300 |  300
+|Max number of key felts per event|The maximum number of felts that an event can contain in its `keys` array. | 50 |  50
 |Max Cairo steps for `validate`| The maximum number of computational steps, measured in Cairo steps, for a `validate` function. | 1,000,000 | 1,000,000
-
-|Max contract bytecode size (Number of felts in the program)| The maximum size of the bytecode or program that a smart contract can have on Starknet.
-
-Bytecode is the low-level code that comprises smart contracts. Limiting this size helps manage the complexity of contracts and the overall efficiency of the network.
-| 81,290 |  81,290
-|Max contract class size|The maximum size for a contract class within Starknet.
-
-Contract classes are a fundamental building block for smart contracts, and limiting their size can have implications for the network's scalability and security.
-| 4,089,446 bytes
-| 4,089,446 bytes
-
-|IP address limits (read/write)| In order to reduce network spam, Starknet limits the amount of contract reads and writes that a single IP
-address can make. | 200 per min per IP address| 200 per min per IP address
-| Signature length (felts) |  | 4,000 |  4,000
-| Calldata length (felts)  |  | 4,000 |  4,000
+|Max contract bytecode size (Number of felts in the program)| The maximum size of the bytecode or program that a smart contract can have on Starknet. Bytecode is the low-level code that comprises smart contracts. Limiting this size helps manage the complexity of contracts and the overall efficiency of the network. | 81,290 |  81,290
+|Max contract class size|The maximum size for a contract class within Starknet. Contract classes are a fundamental building block for smart contracts, and limiting their size can have implications for the network's scalability and security. | 4,089,446 bytes | 4,089,446 bytes
+|IP address limits (read/write)| In order to reduce network spam, Starknet limits the amount of contract reads and writes that a single IP address can make. | 200 per min per IP address| 200 per min per IP address
+|Signature length (felts) |  | 4,000 |  4,000
+|Calldata length (felts)  |  | 4,000 |  4,000
+|Max state diffs per transaction| The maximum number of storage updates (state differences) that a single transaction can generate. This limit helps maintain network stability and predictable performance. | 4,000 | 4,000
 |===


### PR DESCRIPTION
### Description of the Changes

Added missing documentation for limit of state diff size limits-and-triggers section, following the established AsciiDoc format.
Related Issue:- https://github.com/starknet-io/starknet-docs/issues/1321

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1479/tools/limits-and-triggers/

### Check List

- ✅ Changes made against main branch and PR does not conflict
- ✅ PR title is meaningful
- ✅ Detailed description added
- ✅ Specific URL(s) added

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1479)
<!-- Reviewable:end -->
