### PR TITLE
docs: update asdf commands to support all versions

### DIFF
--- a/components/Starknet/modules/quick-start/pages/environment-setup.adoc
+++ b/components/Starknet/modules/quick-start/pages/environment-setup.adoc
@@ -70,6 +70,11 @@ asdf install starknet-devnet latest
 +
 [source,terminal]
 ----
+asdf set -u scarb latest
+asdf set -u starknet-foundry latest
+asdf set -u starknet-devnet latest
+
+# For asdf versions older than 0.16.0:
 asdf global scarb latest
 asdf global starknet-foundry latest
 asdf global starknet-devnet latest


### PR DESCRIPTION
### Description of the Changes

In the `quick-start/environment-setup` page, for setting global versions of Scarb, Starknet Foundry, and Starknet Devnet, it says using `asdf global` command. But this is deprecated after 0.16.0 version. 

So I added new command for setting global versions of them, and also specify commands for old users.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Please paste the specific URL(s) of the content that this PR addresses here.

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"


