### PR TITLE
Fix typo: EIP-4337 corrected to ERC-4337

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/pages/accounts/approach.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/accounts/approach.adoc
@@ -1,7 +1,7 @@
 [id="starknet_account_structure"]
 = Starknet's account interface
 
-Starknet's account structure is inspired by Ethereum's EIP-4337, where instead of EOAs, you use smart contract accounts with arbitrary verification logic.
+Starknet's account structure is inspired by Ethereum's ERC-4337, where instead of EOAs, you use smart contract accounts with arbitrary verification logic.
 
 While not mandatory at the protocol level, you can use a richer standard interface for accounts, defined in link:https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-6.md[Starknet Improvement Proposal #6 (SNIP-6)]. SNIP-6 was developed by community members at OpenZeppelin, in close collaboration with wallet teams and other Core Starknet developers.
 

--- a/components/Starknet/modules/architecture-and-concepts/pages/accounts/introduction.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/pages/accounts/introduction.adoc
@@ -20,7 +20,7 @@ While simple, because the signature scheme is fixed, EOAs have some drawbacks, i
 the account, so you must keep your seed phrase secure yet accessible.
 * Limited flexibility surrounding wallet functionality
 
-EIP-4337 is a design proposal for Ethereum that outlines _account abstraction_, whereby all accounts are managed via a dedicated smart contract on the Ethereum network, as a way to increase flexibility and usability. You can add custom logic on top of the basic EOA functionality, thereby bringing account abstraction into Ethereum.
+ERC-4337 is a design proposal for Ethereum that outlines _account abstraction_, whereby all accounts are managed via a dedicated smart contract on the Ethereum network, as a way to increase flexibility and usability. You can add custom logic on top of the basic EOA functionality, thereby bringing account abstraction into Ethereum.
 
 [id="account_abstraction"]
 == What is Account Abstraction?

--- a/components/Starknet/modules/architecture-and-concepts/partials/snippet_transaction_fields_master_table.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/partials/snippet_transaction_fields_master_table.adoc
@@ -20,7 +20,7 @@ For more information, see link:https://github.com/starknet-io/SNIPs/blob/main/SN
 // DO NOT PUT IN DOCS YET:
 // Used for enabling a paymaster.
 // The list will contain the class_hash and the calldata needed for the constructor.
-// In the future, we might want to use Invoke instead of deploy_account, same as in EIP-4337. In that case, the sender address does not exist - the sequencer will try to deploy a contract with the class hash specified in account_deployment_data.
+// In the future, we might want to use Invoke instead of deploy_account, same as in ERC-4337. In that case, the sender address does not exist - the sequencer will try to deploy a contract with the class hash specified in account_deployment_data.
 
 // Transaction versions that support this field
 // Declare 3


### PR DESCRIPTION
### Description of the Changes

This PR fixes a typo in the documentation where "EIP-4337" was incorrectly referenced instead of "ERC-4337." The correction ensures the terminology aligns with the proper standard naming convention.

### PR Preview URL


### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1526)
<!-- Reviewable:end -->
