### PR TITLE
added missing slashes to .htaccess rules

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -853,7 +853,7 @@ RewriteCond %{QUERY_STRING} ^$
 RewriteRule ^documentation/architecture_and_concepts/Network_Architecture/Blocks/transactions/$ /architecture-and-concepts/network-architecture/transactions/? [R=301,L]
 
 RewriteCond %{QUERY_STRING} ^$
-RewriteRule ^documentation/transaction\-structure\-and\-hash/ /architecture-and-concepts/network-architecture/transactions/? [R=301,L]
+RewriteRule ^documentation/transaction\-structure\-and\-hash/$ /architecture-and-concepts/network-architecture/transactions/? [R=301,L]
 
 RewriteCond %{QUERY_STRING} ^$
 RewriteRule ^documentation/architecture_and_concepts/Network_Architecture/L1\-L2_Communication/token\-bridge/$ /starkgate/overview/? [R=301,L]

--- a/.htaccess
+++ b/.htaccess
@@ -853,7 +853,7 @@ RewriteCond %{QUERY_STRING} ^$
 RewriteRule ^documentation/architecture_and_concepts/Network_Architecture/Blocks/transactions/$ /architecture-and-concepts/network-architecture/transactions/? [R=301,L]
 
 RewriteCond %{QUERY_STRING} ^$
-RewriteRule ^documentation/transaction\-structure\-and\-hash/$  /architecture-and-concepts/network-architecture/transactions/? [R=301,L]
+RewriteRule ^documentation/transaction\-structure\-and\-hash/ /architecture-and-concepts/network-architecture/transactions/? [R=301,L]
 
 RewriteCond %{QUERY_STRING} ^$
 RewriteRule ^documentation/architecture_and_concepts/Network_Architecture/L1\-L2_Communication/token\-bridge/$ /starkgate/overview/? [R=301,L]
@@ -902,23 +902,23 @@ RewriteRule ^documentation/tools/CLI/starknet\-compiler\-options/$ /cli/starknet
 
 RewriteRule ^tools/starknet\-book/$ / [R=301,L]
 
-RewriteRule ^tools/devtools/clis/$ tools/devtools/overview? [R=301,L]
+RewriteRule ^tools/devtools/clis/$ /tools/devtools/overview? [R=301,L]
 
-RewriteRule ^tools/devtools/sdks/$ tools/devtools/overview? [R=301,L]
+RewriteRule ^tools/devtools/sdks/$ /tools/devtools/overview? [R=301,L]
 
-RewriteRule ^tools/devtools/dapp-frameworks/$ tools/devtools/overview? [R=301,L]
+RewriteRule ^tools/devtools/dapp-frameworks/$ /tools/devtools/overview? [R=301,L]
 
-RewriteRule ^tools/devtools/libs-for-dapps/$ tools/devtools/overview? [R=301,L]
+RewriteRule ^tools/devtools/libs-for-dapps/$ /tools/devtools/overview? [R=301,L]
 
-RewriteRule ^tools/devtools/devnets/$ tools/devtools/overview? [R=301,L]
+RewriteRule ^tools/devtools/devnets/$ /tools/devtools/overview? [R=301,L]
 
-RewriteRule ^tools/devtools/smart-contract-tools/$ tools/devtools/overview? [R=301,L]
+RewriteRule ^tools/devtools/smart-contract-tools/$ /tools/devtools/overview? [R=301,L]
 
-RewriteRule ^tools/devtools/vscode/$ tools/devtools/overview? [R=301,L]
+RewriteRule ^tools/devtools/vscode/$ /tools/devtools/overview? [R=301,L]
 
-RewriteRule ^tools/devtools/utilities/$ tools/devtools/overview? [R=301,L]
+RewriteRule ^tools/devtools/utilities/$ /tools/devtools/overview? [R=301,L]
 
-RewriteRule ^tools/devtools/security/$ tools/devtools/overview? [R=301,L]
+RewriteRule ^tools/devtools/security/$ /tools/devtools/overview? [R=301,L]
 
 RewriteRule ^documentation/architecture_and_concepts/Smart_Contracts/system-calls/$ /architecture-and-concepts/smart-contracts/system-calls-cairo1/? [R=301,L]
 


### PR DESCRIPTION
### Description of the Changes

I'm part of the team maintaining the starknet.io website and a web developer. I have received a report from the company about poorly written redirects on the docs site. This PR includes the addition of slashes to the .htaccess target URLs, where slashes were missing. 

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1530/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1530)
<!-- Reviewable:end -->
