### PR TITLE
generalized ROOT/index replacement for algolia indexing

### DIFF
--- a/js/algolia-index.js
+++ b/js/algolia-index.js
@@ -111,7 +111,7 @@ const startIndexing = (currentBranch) => {
         .split("modules")[1]
         .replace("/pages", "")
         .replace(".adoc", "")
-        .replace("ROOT/index", "")
+        .replace(/ROOT\/[^/]+/, "")
         .replace("index", "")
       const record = {
         url: "https://docs.starknet.io" + url,


### PR DESCRIPTION
### Description of the Changes

I'm part of the team maintaining the starknet.io website and a web developer. I have received a report from the company about an issue with the way some URLs are being indexed with the ROOT keyword in Algolia. This PR includes the fix to the .replace() function in the Algolia indexing file, generalizing it to replace all URLs preceded by ROOT and not only ROOT/index, which is the current condition for omitting that string.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1533/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1533)
<!-- Reviewable:end -->
