### PR TITLE
Fix displaying `l1_data_gas_bounds` in txs docs

### DIFF
--- a/components/Starknet/modules/architecture-and-concepts/partials/snippet_transaction_params.adoc
+++ b/components/Starknet/modules/architecture-and-concepts/partials/snippet_transaction_params.adoc
@@ -13,7 +13,7 @@
 \underbrace{\text{L2_GAS}}_{\text{60 bits}} | \underbrace{\text{max_amount}}_{\text{64 bits}} |
 \underbrace{\text{max_price_per_unit}}_{\text{128 bits}}
 ++++
-* `l1_gas_bounds` is constructed as follows:
+* `l1_data_gas_bounds` is constructed as follows:
 +
 [stem]
 ++++


### PR DESCRIPTION
### Description of the Changes

Fix displaying l1 data gas bounds in transactions docs.

Before:

![image](https://github.com/user-attachments/assets/43b97d67-7d3c-40fd-833a-0765f146957a)

After:
![image](https://github.com/user-attachments/assets/b379df28-034d-49de-8f1e-288c1dc32eb7)


### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1534/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1534)
<!-- Reviewable:end -->
