### PR TITLE
docs: update installation script for Scarb and Starknet Foundry to use Starkup

### DIFF
--- a/components/Starknet/modules/quick-start/pages/environment-setup.adoc
+++ b/components/Starknet/modules/quick-start/pages/environment-setup.adoc
@@ -35,54 +35,67 @@ or install the latest Rust version by following the instructions in the https://
 
 === MacOS and Linux
 
-It is highly recommended to install Scarb, Starknet Foundry, and Starknet Devnet on MacOS and Linux via the link:https://asdf-vm.com/[`asdf` version manager], as it allows to easily switch between their different versions, both globally and per project (see full details in the link:https://asdf-vm.com/manage/commands.html[`asdf` documentation] or by running `asdf --help`).
+You can install Scarb and Starknet Foundry via the link:https://github.com/software-mansion/starkup[Starkup]. Starkup uses the link:https://asdf-vm.com/[`asdf` version manager] under the hood to install these tools, which makes easy to switch between different versions—both globally and on a per-project basis (see full details in the link:https://asdf-vm.com/manage/commands.html[`asdf` documentation] or by running `asdf --help`). 
+
+While Starkup automatically installs `asdf`, you may need to update it manually later. If you prefer to install `asdf` on your own, follow the instructions in the link:https://asdf-vm.com/guide/getting-started.html[`asdf` documentation].
+
+Starkup installs the following tools:
+
+* _Scarb_, the Cairo package manager
+* _Starknet Foundry_, the Cairo and Starknet testing framework
+* _Universal Sierra Compiler_, compiler for any ever-existing Sierra version
+* _Cairo Profiler_, profiler for Cairo programming language & Starknet
+* _Cairo Coverage_, utility for coverage reports generation for code written in Cairo programming language
+* _CairoLS_, vscode extension
+
+Note that Starkup does not install Starknet Devnet, so you will need to install it separately using `asdf`.
 
 .Procedure
 
-. Verify that `asdf` is installed:
+. Install Scarb and Starknet Foundry via Starkup:
 +
 [source,terminal]
 ----
-asdf --version
+curl --proto '=https' --tlsv1.2 -sSf https://sh.starkup.dev | sh
 ----
 +
-or install it by following the instructions in the link:https://asdf-vm.com/guide/getting-started.html[`asdf` documentation].
+Follow the instructions displayed on the screen.
 
-. Install the `asdf` Scarb, Starknet Foundry, and Starknet Devnet plugins:
-+
-[source,terminal]
-----
-asdf plugin add scarb
-asdf plugin add starknet-foundry
-asdf plugin add starknet-devnet
-----
-
-. Install the latest versions of Scarb, Starknet Foundry, and Starknet Devnet:
-+
-[source,terminal]
-----
-asdf install scarb latest
-asdf install starknet-foundry latest
-asdf install starknet-devnet latest
-----
-
-. Set global versions for Scarb, Starknet Foundry, and Starknet Devnet:
-+
-[source,terminal]
-----
-asdf global scarb latest
-asdf global starknet-foundry latest
-asdf global starknet-devnet latest
-----
-
-. Restart the terminal and verify that Scarb, Starknet Foundry, and Starknet Devnet are installed correctly:
+. Verify that Scarb and Starknet Foundry are installed correctly:
 +
 [source,terminal]
 ----
 scarb --version
 snforge --version && sncast --version
+----
+
+. Install the Starknet Devnet plugin via `asdf`:
++
+[source,terminal]
+----
+asdf plugin add starknet-devnet
+----
+
+. Install the latest versions of Starknet Devnet:
++
+[source,terminal]
+----
+asdf install starknet-devnet latest
+----
+or
++
+[source,terminal]
+----
+asdf install starknet-devnet
+----
+
+. Verify that Starknet Devnet is installed correctly:
++
+[source,terminal]
+----
 starknet-devnet --version
 ----
+
 
 === Windows
 


### PR DESCRIPTION
### Description of the Changes

I've updated the `quick-start/environment-setup` page to use Starkup for installing Scarb and Starknet Foundry, while maintaining the existing `asdf` command script for installing Starknet Devnet.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1543/quick-start/environment-setup/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1543)
<!-- Reviewable:end -->
