### PR TITLE
Quickstart Rust issue

### DIFF
--- a/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
+++ b/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
@@ -48,7 +48,7 @@ Starting from Scarb version 2.10 and Starknet Foundry version 0.37.0, Rust is lo
 allow-prebuilt-plugins = ["snforge_std"]
 ----
 
-If not all three conditions are and Rust is not installed, running `scarb build` (and `scarb test`) will result in a compilation error. To resolve this, either update Scarb, Starknet Foundry, and your `Scarb.toml` file accordingly or https://www.rust-lang.org/tools/install[install Rust^]. 
+If not all three conditions are met and Rust is not installed, running `scarb build` (and `scarb test`) will result in a compilation error. To resolve this, either update Scarb, Starknet Foundry, and your `Scarb.toml` file accordingly or https://www.rust-lang.org/tools/install[install Rust^]. 
 
 === `starkli declare` unable to identify compiler version
 

--- a/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
+++ b/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
@@ -100,8 +100,32 @@ and entering the private key of your smart wallet, along with a password that wi
 ----
 starkli account fetch \
     <SMART_WALLET_ADDRESS> \
-    --output account.json
+    --output account.json \
     --network=sepolia
 ----
 
+== Miscellaneous
 
+=== scarb test fails to run version command for Rust
+
+Starting from Scarb version 2.10 and Starknet Foundry version 0.37.0, Rust is longer required for projects with the following line in the `Scarb.toml` file:
+
+[source,cairo]
+----
+[tool.scarb]
+allow-prebuilt-plugins = ["snforge_std"]
+----
+
+If you don't have all three rules met, and you don't have Rust installed, you will get the following compilation error when running tests with Starknet Foundry:
+
+[source,terminal]
+----
+error: could not execute process: cargo build
+
+Caused by:
+    No such file or directory (os error 2)
+error: could not compile `snforge_scarb_plugin` due to previous error
+[ERROR] Failed to build test artifacts with Scarb: `scarb` exited with error
+----
+
+To resolve this, simply update Scarb, Starknet Foundry, and your `Scarb.toml` file according to the aforementioned conditions. 

--- a/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
+++ b/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
@@ -40,7 +40,7 @@ source ~/.bashrc
 
 === `scarb build` fails to run version command for Rust
 
-Starting from Scarb version 2.10 and Starknet Foundry version 0.37.0, Rust is longer required for projects with the following line in the `Scarb.toml` file:
+Starting from Scarb version 2.10 and Starknet Foundry version 0.37.0, Rust is longer required for projects with their following line in the `Scarb.toml` file:
 
 [source,cairo]
 ----
@@ -48,7 +48,7 @@ Starting from Scarb version 2.10 and Starknet Foundry version 0.37.0, Rust is lo
 allow-prebuilt-plugins = ["snforge_std"]
 ----
 
-If you don't have all three rules met, and you don't have Rust installed, you will get a compilation error when running `scarb build` (and `scarb test`). To resolve this, simply update Scarb, Starknet Foundry, and your `Scarb.toml` file according to the aforementioned conditions. If you wish to continue using older version of Scarb and Starknet Foundry, you can https://www.rust-lang.org/tools/install[install Rust^] instead. 
+If not all three conditions are and Rust is not installed, running `scarb build` (and `scarb test`) will result in a compilation error. To resolve this, either update Scarb, Starknet Foundry, and your `Scarb.toml` file accordingly or https://www.rust-lang.org/tools/install[install Rust^]. 
 
 === `starkli declare` unable to identify compiler version
 

--- a/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
+++ b/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
@@ -38,6 +38,18 @@ source ~/.bashrc
 
 == Declaring, deploying, and interacting with HelloStarknet locally
 
+=== `scarb build` fails to run version command for Rust
+
+Starting from Scarb version 2.10 and Starknet Foundry version 0.37.0, Rust is longer required for projects with the following line in the `Scarb.toml` file:
+
+[source,cairo]
+----
+[tool.scarb]
+allow-prebuilt-plugins = ["snforge_std"]
+----
+
+If you don't have all three rules met, and you don't have Rust installed, you will get a compilation error when running `scarb build` (and `scarb test`). To resolve this, simply update Scarb, Starknet Foundry, and your `Scarb.toml` file according to the aforementioned conditions. If you wish to continue using older version of Scarb and Starknet Foundry, you can https://www.rust-lang.org/tools/install[install Rust^] instead. 
+
 === `starkli declare` unable to identify compiler version
 
 When using `starkli declare`, Starkli will do its best to identify the compiler version of the declared class. In case it fails, the `--compiler-version` flag can be used to specify the version of the compiler.
@@ -103,29 +115,3 @@ starkli account fetch \
     --output account.json \
     --network=sepolia
 ----
-
-== Miscellaneous
-
-=== scarb test fails to run version command for Rust
-
-Starting from Scarb version 2.10 and Starknet Foundry version 0.37.0, Rust is longer required for projects with the following line in the `Scarb.toml` file:
-
-[source,cairo]
-----
-[tool.scarb]
-allow-prebuilt-plugins = ["snforge_std"]
-----
-
-If you don't have all three rules met, and you don't have Rust installed, you will get the following compilation error when running tests with Starknet Foundry:
-
-[source,terminal]
-----
-error: could not execute process: cargo build
-
-Caused by:
-    No such file or directory (os error 2)
-error: could not compile `snforge_scarb_plugin` due to previous error
-[ERROR] Failed to build test artifacts with Scarb: `scarb` exited with error
-----
-
-To resolve this, simply update Scarb, Starknet Foundry, and your `Scarb.toml` file according to the aforementioned conditions. 

--- a/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
+++ b/components/Starknet/modules/quick-start/pages/troubleshooting.adoc
@@ -40,7 +40,7 @@ source ~/.bashrc
 
 === `scarb build` fails to run version command for Rust
 
-Starting from Scarb version 2.10 and Starknet Foundry version 0.37.0, Rust is longer required for projects with their following line in the `Scarb.toml` file:
+Starting from Scarb version 2.10 and Starknet Foundry version 0.37.0, Rust is longer required for projects with the following line in their `Scarb.toml` file:
 
 [source,cairo]
 ----


### PR DESCRIPTION
### Description of the Changes

Documented a Rust issue to the quickstart troubleshooting page.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1554/quick-start/troubleshooting/#scarb_build_fails_to_run_version_command_for_rust

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1554)
<!-- Reviewable:end -->
