### PR TITLE
docs: fix typos in Starknet instance initialization section

### DIFF
--- a/components/Starknet/modules/quick-start/pages/devnet.adoc
+++ b/components/Starknet/modules/quick-start/pages/devnet.adoc
@@ -1,4 +1,4 @@
-[id="using_starknet_devnet]
+[id="using_starknet_devnet"]
 
 = Declaring, deploying, and interacting with the `HelloStarknet` contract locally
 
@@ -12,7 +12,7 @@ Local networks, also known as development networks or _devnets_, enable a fast a
 
 == Initializing a local Starknet instance
 
-A local Starknet instance can be easily initialized using Starknet Devent by simply running:
+A local Starknet instance can be easily initialized using Starknet Devnet by simply running:
 
 [source,terminal]
 ----


### PR DESCRIPTION
### Description of the Changes

I fixed a couple of typos in the documentation:  

1. The closing bracket for the `id="using_starknet_devnet"` was missing, which has now been corrected.  
2. "Starknet Devent" was mistakenly written instead of the correct "Starknet Devnet."

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1561/quick-start/environment-setup/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1561)
<!-- Reviewable:end -->
