### PR TITLE
docs: fix typo in Delegation Pooling Contract section

### DIFF
--- a/components/Starknet/modules/staking/pages/architecture.adoc
+++ b/components/Starknet/modules/staking/pages/architecture.adoc
@@ -60,7 +60,7 @@ The staking contract is the core of the staking system. It manages the entire li
 
 == Delegation Pooling Contract
 
-The delegation pooling contract enables users to delegate their tokens. All interactions, such as entering or exiting the pool, are enabled through this contracts, which tracks each delegator's contribution, calculates their rewards, and manages the delegation lifecycle.
+The delegation pooling contract enables users to delegate their tokens. All interactions, such as entering or exiting the pool, are enabled through this contract, which tracks each delegator's contribution, calculates their rewards, and manages the delegation lifecycle.
 
 *Key Functions and Responsibilities*: +
 `enter_delegation_pool`: Allows users to delegate their tokens to the pool associated with a validator. This function transfers the tokens, updates the delegator's record, and integrates them into the validator's pool. +


### PR DESCRIPTION
### Description of the Changes

Fixed typo in the "Delegation Pooling Contract" section where the phrase "through this contracts" was used.
It has been updated to "through this contract" to ensure proper grammar and clarity.

### PR Preview URL


### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1562)
<!-- Reviewable:end -->
