### PR TITLE
Fix of CODESPECT domain in auditors-security-platforms.adoc

### DIFF
--- a/components/Starknet/modules/ecosystem/pages/auditors-security-platforms.adoc
+++ b/components/Starknet/modules/ecosystem/pages/auditors-security-platforms.adoc
@@ -23,7 +23,7 @@
 | https://chainsecurity.com/[chainsecurity.com^]
 
 | CODESPECT
-| https://codespect.xyz/[codespect.xyz^]
+| https://codespect.net/[codespect.net^]
 
 | ConsenSys
 | http://consensys.net/diligence[consensys.net/diligence^]


### PR DESCRIPTION
### Description of the Changes

We have changed the CODESPECT domain from `codespect.xyz` to `codespect.net` because of SEO optimization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1565)
<!-- Reviewable:end -->
