### PR TITLE
Fix max bytecode size in chain-info.adoc

### DIFF
--- a/components/Starknet/modules/resources/pages/chain-info.adoc
+++ b/components/Starknet/modules/resources/pages/chain-info.adoc
@@ -139,8 +139,8 @@ This limit is important for ensuring the efficient execution of transactions and
 | The maximum size of the bytecode or program that a smart contract can have on Starknet.
 
 Bytecode is the low-level code that comprises smart contracts. Limiting this size helps manage the complexity of contracts and the overall efficiency of the network.
-| 81,290
-|  81,290
+| 81,920
+| 81,920
 | Max contract class size
 | The maximum size for a contract class within Starknet.
 

--- a/components/Starknet/modules/resources/pages/chain-info.adoc
+++ b/components/Starknet/modules/resources/pages/chain-info.adoc
@@ -135,7 +135,7 @@ This limit is important for ensuring the efficient execution of transactions and
 | 1,000,000
 | 1,000,000
 
-| Max contract bytecode size
+| Max contract bytecode size (felts)
 | The maximum size of the bytecode or program that a smart contract can have on Starknet.
 
 Bytecode is the low-level code that comprises smart contracts. Limiting this size helps manage the complexity of contracts and the overall efficiency of the network.


### PR DESCRIPTION
### Description of the Changes

Fixing a likely typo, based on: https://github.com/starkware-libs/sequencer/blob/main/crates/blockifier/resources/blockifier_versioned_constants_0_14_0.json#L9

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1571/resources/chain-info/#current_limits

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1571)
<!-- Reviewable:end -->
