### PR TITLE
Fix broken link and typo

### DIFF
--- a/components/Starknet/modules/starkgate/pages/overview.adoc
+++ b/components/Starknet/modules/starkgate/pages/overview.adoc
@@ -22,9 +22,9 @@ This guide will walk you through the various procedures enabled by StarkGate, in
 
 * https://docs.starknet.io/starkgate/cancelling-a-deposit/[Canceling a deposit]: Canceling a previous deposit or deposit with message, if you don't see your deposited funds appear on L2 within a reasonable amount of time.
 
-* https://docs.starknet.io/starkgate/withdrawing/[Withdrawaling funds]: Withdrawing ETH and ERC-20 tokens from your L2 wallet on Starknet to your L1 wallet on Ethereum, using a burn-and-unlock mechanism.
+* https://docs.starknet.io/starkgate/withdrawing/[Withdrawing funds]: Withdrawing ETH and ERC-20 tokens from your L2 wallet on Starknet to your L1 wallet on Ethereum, using a burn-and-unlock mechanism.
 
-* https://research.lazer1.xyz/blog/making-sense-of-starknet-architecture-and-l1-l2-messaging/#enroll-a-token-bridge[Adding a token^]: Permissionlessly enrolling a token bridge on StarkGate.
+* https://9oelm.github.io/2024-03-28-making-sense-of-starknet-architecture-and-l1-l2-messaging/#enroll-a-token-bridge[Adding a token^]: Permissionlessly enrolling a token bridge on StarkGate.
 
 [NOTE]
 ====


### PR DESCRIPTION
### Description of the Changes

The current link to "enrolling a token" is broken. Changed it to an original link from the same author.
Also fixed a typo in the previous link text.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1575/starkgate/overview/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1575)
<!-- Reviewable:end -->
