### PR TITLE
Add Trustblock to security platforms list

### DIFF
--- a/components/Starknet/modules/ecosystem/pages/auditors-security-platforms.adoc
+++ b/components/Starknet/modules/ecosystem/pages/auditors-security-platforms.adoc
@@ -71,4 +71,7 @@ https://www.zellic.io/[zellic.io^]
 
 | Hypernative
 | https://www.hypernative.io/[hypernative.io^]
+
+| Trustblock
+| https://trustblock.run/[trustblock.run^]
 |===


### PR DESCRIPTION
Includes Trustblock (trustblock.run) as a relevant security platform resource.

### Description of the Changes

Added Trustblock (https://trustblock.run/) to the list of Security Platforms in the auditors-security-platforms.adoc file. Trustblock provides on-chain security data and tooling relevant to the ecosystem.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Please paste the specific URL(s) of the content that this PR addresses here.

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [ ] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1576)
<!-- Reviewable:end -->
