### PR TITLE
Remove Nethermind from the list of open RPC endpoints

### DIFF
--- a/components/Starknet/modules/ecosystem/pages/open-rpc-endpoints-sepolia-faucets.adoc
+++ b/components/Starknet/modules/ecosystem/pages/open-rpc-endpoints-sepolia-faucets.adoc
@@ -20,10 +20,6 @@
 | \https://rpc.starknet.lava.build:443[]
 | \https://rpc.starknet-testnet.lava.build:443
 
-| Nethermind
-| \https://free-rpc.nethermind.io/mainnet-juno
-| \https://free-rpc.nethermind.io/sepolia-juno
-
 | OnFinality
 | \https://starknet.api.onfinality.io/public (HTTPS) +
 wss://starknet.api.onfinality.io/public-ws (WebSocket)


### PR DESCRIPTION
### Description of the Changes

Remove Nethermind from the list of open RPC endpoints

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

https://starknet-io.github.io/starknet-docs/pr-1611/ecosystem/open-rpc-endpoints-sepolia-faucets/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1611)
<!-- Reviewable:end -->
