### PR TITLE
Fix StarkGate architecture diagram display

### DIFF
--- a/components/Starknet/modules/starkgate/pages/architecture.adoc
+++ b/components/Starknet/modules/starkgate/pages/architecture.adoc
@@ -10,7 +10,7 @@ This page is a deep-dive into StarkGate's different components. To learn how to 
 
 https://starkgate.starknet.io[StarkGate^], developed by StarkWare, bridges ETH and ERC-20 tokens between Ethereum and Starknet. The following is an illustration of its overall architecture:
 
-image::sg-architecture.png[]
+image::https://github.com/starknet-io/starknet-docs/blob/main/components/Starknet/modules/starkgate/images/sg-architecture.png[StarkGate Architecture]
 
 As illustrated, while StarkGate is referred to as a single bridge, some xref:#legacy_bridge[legacy tokens] have their own bridge, each of which is defined in a corresponding pair of L1 and L2 contracts. Moreover, StarkGate also includes additional xref:#l1_components[L1 components], used for administrative purposes. To best understand the interplay between the different components, it's recommended to follow the xref:#lifecycles[lifecycles of a deposit and withdrawal].
 


### PR DESCRIPTION
### Description of the Changes
- Updated the image reference in architecture.adoc to use the direct GitHub URL
- Added alt text "StarkGate Architecture" for improved accessibility
- Replaced local image path with working remote URL to ensure diagram displays correctly

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1621/starkgate/architecture/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1621)
<!-- Reviewable:end -->
