### PR TITLE
chore(ci): upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
         run: yarn generate
 
       - name: "Upload generated content"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: starknet-site
           if-no-files-found: error


### PR DESCRIPTION
Updated workflows to use actions/upload-artifact@v4 for better reliability and performance. See release notes at https://github.com/actions/upload-artifact/releases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1671)
<!-- Reviewable:end -->
