### PR TITLE
Update pathfinder.adoc

### DIFF
--- a/modules/guides/pages/becoming-a-validator/pathfinder.adoc
+++ b/modules/guides/pages/becoming-a-validator/pathfinder.adoc
@@ -95,7 +95,8 @@ docker run \
   -e RUST_LOG=info \
   -e PATHFINDER_ETHEREUM_API_URL=$ETHEREUM_URL \
   -v $HOME/pathfinder:/usr/share/pathfinder/data \
-  eqlabs/pathfinder
+  eqlabs/pathfinder \
+  --rpc.websocket.enabled
 ----
 
 Once the docker container is up and running, you can check the docker image's logs by running: 


### PR DESCRIPTION
### Description of the Changes

This PR adds the `--rpc.websocket.enabled` flag to the `docker run` command for starting a Pathfinder node.

Starting from version `v0.17.0`, WebSocket RPC is disabled by default. This flag is required to enable WebSocket functionality, which is critical for services such as the attestation service to function properly. Without it, real-time block event subscriptions will not work, leading to missed attestations and failed validator behavior.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1675/guides/becoming-a-validator/pathfinder/#running_the_node

### Check List

- [x] Changes made against main branch and PR does not conflict  
- [x] PR title is meaningful, e.g. `add --rpc.websocket.enabled to pathfinder docker run`  
- [x] Detailed description added under "Description of the Changes"  
- [x] Specific URL(s) added under "PR Preview URL" (if applicable)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1675)
<!-- Reviewable:end -->
