### PR TITLE
Update pathfinder.adoc

### DIFF
--- a/modules/guides/pages/becoming-a-validator/pathfinder.adoc
+++ b/modules/guides/pages/becoming-a-validator/pathfinder.adoc
@@ -132,6 +132,13 @@ docker stop pathfinder
 
 == Running Pathfinder's attestation service
 
+[NOTE]
+====
+The `operational address` used for attestation **must not be protected by a guardian**, such as Argent Guardian or Braavos hardware signer.
+
+Accounts with guardians or hardware-bound signing will **not work**, as the attestation service requires local signing.
+====
+
 Luckily, running https://github.com/eqlabs/starknet-validator-attestation/tree/main[Pathfinder's attestation service^] is as simple as running:
 
 [source,terminal]


### PR DESCRIPTION
- Added an [NOTE] about avoiding guardians/hardware wallets for the operational address

### Description of the Changes

This PR improves the documentation for running a Pathfinder node and attestation service.


- Adds a note clarifying that the operational address used for attestations must not be protected by a guardian (e.g., Argent or Braavos hardware signers), as local signing is required.

### PR Preview URL

N/A

### Check List

- [x] Changes made against `main` branch and PR does not conflict  
- [x] PR title is meaningful  
- [x] Description added under "Description of the Changes"  
- [x] Technical additions are verified against latest Pathfinder version  
- [ ] Specific URL(s) added under "PR Preview
