### PR TITLE
Update staking.adoc

### DIFF
--- a/modules/architecture/pages/staking.adoc
+++ b/modules/architecture/pages/staking.adoc
@@ -99,7 +99,7 @@ To reduce exposure to threats and enhance security, multiple addresses are defin
 +
 [IMPORTANT]
 ====
-If your operational address uses local signing, the account assosiated with it must be deployed and unprotected (e.g., no Ready Wallet Guardian or Braavos hardware signer).
+If your operational address uses local signing, the account associated with it must be deployed and unprotected (e.g., no Ready Wallet Guardian or Braavos hardware signer).
 ====
 
 * Delegator addresses:

--- a/modules/architecture/pages/staking.adoc
+++ b/modules/architecture/pages/staking.adoc
@@ -97,6 +97,13 @@ To reduce exposure to threats and enhance security, multiple addresses for defin
 
 ** Operational Address: Used for operational purposes, such as block attestations (starting from the protocol's second phase), block proposing (starting from the protocol's third phase), etc. This address is used frequently and doesn't handle large amounts of funds, and therefore is best kept by a hot wallet. Starting from the protocol's second phase, however, hacking the operational address can lead to a lose of yield for the validator and its delegators.
 
+[IMPORTANT]
+====
+The operational address **must not be protected by a guardian**, such as Argent Guardian or Braavos hardware signer.
+
+It must support **local signing**, otherwise the attestation service will not be able to submit attestations.
+====
+
 * Delegator addresses:
 
 ** Staking address: Used for delegating stake, adding stake and unstaking. This address is only needed when entering or exiting the protocol and handles large amounts of STRK, and therefore is best kept by a cold wallet with minimal activity.

--- a/modules/architecture/pages/staking.adoc
+++ b/modules/architecture/pages/staking.adoc
@@ -99,9 +99,11 @@ To reduce exposure to threats and enhance security, multiple addresses for defin
 
 [IMPORTANT]
 ====
-The operational address **must not be protected by a guardian**, such as Argent Guardian or Braavos hardware signer.
+If you are using local signing, make sure of the following:
+1) Your Operational Address is **not protected** (e.g., no Ready Wallet Guardian (formerly Argent Guardian) or Braavos hardware signer).
+2) Your Operational Address is **already deployed** on the network.
 
-It must support **local signing**, otherwise the attestation service will not be able to submit attestations.
+Otherwise, you **will not be able to sign attestations**.
 ====
 
 * Delegator addresses:

--- a/modules/architecture/pages/staking.adoc
+++ b/modules/architecture/pages/staking.adoc
@@ -87,7 +87,7 @@ Validators can choose whether to allow delegation or not.
 
 === Addresses
 
-To reduce exposure to threats and enhance security, multiple addresses for defined for both validators and delegators:
+To reduce exposure to threats and enhance security, multiple addresses are defined for both validators and delegators:
 
 * Validator addresses:
 
@@ -96,14 +96,10 @@ To reduce exposure to threats and enhance security, multiple addresses for defin
 ** Rewards Address: Used for receiving rewards. This address is only needed when receiving rewards, and therefore is best kept by a cold wallet.
 
 ** Operational Address: Used for operational purposes, such as block attestations (starting from the protocol's second phase), block proposing (starting from the protocol's third phase), etc. This address is used frequently and doesn't handle large amounts of funds, and therefore is best kept by a hot wallet. Starting from the protocol's second phase, however, hacking the operational address can lead to a lose of yield for the validator and its delegators.
-
++
 [IMPORTANT]
 ====
-If you are using local signing, make sure of the following:
-1) Your Operational Address is **not protected** (e.g., no Ready Wallet Guardian (formerly Argent Guardian) or Braavos hardware signer).
-2) Your Operational Address is **already deployed** on the network.
-
-Otherwise, you **will not be able to sign attestations**.
+If your operational address uses local signing, the account assosiated with it must be deployed and unprotected (e.g., no Ready Wallet Guardian or Braavos hardware signer).
 ====
 
 * Delegator addresses:


### PR DESCRIPTION
### Description of the Changes

This PR improves the staking documentation by:

- Adding an `[IMPORTANT]` notice below the *Operational Address* section
- Explaining that the attestation operational address **must support local signing**
- Warning users not to use **Argent, Braavos**, or other guardian/hardware-protected accounts, which are incompatible with the attestation service

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1677/architecture/staking/#addresses

### Check List

- [x] Changes made against `main` branch and PR does not conflict  
- [x] PR title is meaningful  
- [x] Description explains why the change is necessary  
- [x] Style/formatting matches existing docs  
- [x] Specific Preview URL added (if required by project)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1677)
<!-- Reviewable:end -->
