### PR TITLE
Update Epoch length for Sepolia

### DIFF
--- a/modules/architecture/pages/staking.adoc
+++ b/modules/architecture/pages/staking.adoc
@@ -57,7 +57,7 @@ The following sections describe the details of Starknet's staking protocol. The 
 
 | Epoch length (stem:[E])
 | 120 blocks
-| 692 blocks
+| 231 blocks
 
 | Epoch duration
 | 3600 seconds


### PR DESCRIPTION
### Description of the Changes

Updated the Epoch length (E) value for Sepolia from 692 (?) to 231 to reflect reality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1679)
<!-- Reviewable:end -->
