### PR TITLE
fix: update broken link to Sierra documentation in glossary

### DIFF
--- a/modules/archive/pages/glossary.adoc
+++ b/modules/archive/pages/glossary.adoc
@@ -129,7 +129,7 @@ An intermediate representation between Cairo and Casm. Sierra code is then compi
 
 .Additional resources
 
-* link:https://docs.starknet.io/architecture/smart-contracts/cairo-and-sierra/[Cairo and Sierra]
+* link:https://book.cairo-lang.org/appendix-09-sierra.html[Cairo and Sierra]
 
 [#stark]
 == STARK


### PR DESCRIPTION
### Description of the Changes

Replace broken link to Cairo and Sierra documentation in the glossary. Update from the non-working URL (docs.starknet.io/architecture/smart-contracts/cairo-and-sierra/) to the correct URL in Cairo Book (book.cairo-lang.org/appendix-09-sierra.html) that matches .htaccess redirect rules

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1683/archive/glossary/#sierra

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1683)
<!-- Reviewable:end -->
