### PR TITLE
Update chain-info.adoc with network versions

### DIFF
--- a/modules/resources/pages/chain-info.adoc
+++ b/modules/resources/pages/chain-info.adoc
@@ -13,8 +13,8 @@ You can get the latest updates delivered to your inbox by subscribing to the htt
 |===
 |Environment |Starknet version|Sierra version|Cairo version
 
-|Mainnet|0.13.5|1.7.0|2.0.0 - 2.11.0
-|Sepolia|0.13.5|1.7.0|2.0.0 - 2.11.0
+|Mainnet|0.13.6|1.7.0|2.0.0 - 2.11.0
+|Sepolia|0.14.0|1.7.0|2.0.0 - 2.11.0
 |===
 
 == Current limits


### PR DESCRIPTION
### Description of the Changes

Update mainnet to v0.13.6 and Sepolia to v0.14.0.


### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1685/resources/chain-info/

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1685)
<!-- Reviewable:end -->
