### PR TITLE
Minor typo fix in SHARP page

### DIFF
--- a/modules/architecture/pages/sharp.adoc
+++ b/modules/architecture/pages/sharp.adoc
@@ -59,7 +59,7 @@ Since its inception, SHARP has undergone a handful of efficiency upgrades, with 
 
 In the linear model, SHARP waited for enough programs to "fill up" a proof, and only then started the proving process for the whole bundle of programs.
 
-In the recursive model, SHARP proves each statement upon its arrival, and instead of verifying it onchain, it verifies it offchain using a verifier program written in Cairo. Each two instances of execution of the this verifier program are then aggregated into a single proof, and are then sent back to SHARP and the Cairo verifier, restarting the process. This continues recursively, with each new proof being sent to the Cairo verifier until a trigger is reached. At this point, the last proof in the series is sent to the Solidity verifier on Ethereum.
+In the recursive model, SHARP proves each statement upon its arrival, and instead of verifying it onchain, it verifies it offchain using a verifier program written in Cairo. Each two such verifications are then aggregated together and sent back to SHARP and the Cairo verifier, restarting the process. This continues recursively, with each new proof being sent to the Cairo verifier until a trigger is reached. At this point, the last proof in the series is sent to the Solidity verifier on Ethereum.
 
 At first glance, recursive proofs may seem more complex and time-consuming. However, there are several benefits to this approach:
 

--- a/modules/architecture/pages/sharp.adoc
+++ b/modules/architecture/pages/sharp.adoc
@@ -59,7 +59,7 @@ Since its inception, SHARP has undergone a handful of efficiency upgrades, with 
 
 In the linear model, SHARP waited for enough programs to "fill up" a proof, and only then started the proving process for the whole bundle of programs.
 
-In the recursive model, SHARP proves each statement upon its arrival, and instead of verifying it onchain, it verifies it offchain using a verifier program written in Cairo. Each two of execution of the this verifier program are then aggregated into a single proof, and are then sent back to SHARP and the Cairo verifier, restarting the process. This continues recursively, with each new proof being sent to the Cairo verifier until a trigger is reached. At this point, the last proof in the series is sent to the Solidity verifier on Ethereum.
+In the recursive model, SHARP proves each statement upon its arrival, and instead of verifying it onchain, it verifies it offchain using a verifier program written in Cairo. Each two instances of execution of the this verifier program are then aggregated into a single proof, and are then sent back to SHARP and the Cairo verifier, restarting the process. This continues recursively, with each new proof being sent to the Cairo verifier until a trigger is reached. At this point, the last proof in the series is sent to the Solidity verifier on Ethereum.
 
 At first glance, recursive proofs may seem more complex and time-consuming. However, there are several benefits to this approach:
 


### PR DESCRIPTION
### Description of the Changes

Added the word "instances" to account for a missing word in the text "each two ??? of execution".
Can be another word, but something is missing..

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1689/architecture/sharp/#proof_recursion

### Check List

- [x] Changes made against main branch and PR does not conflict
- [x] PR title is meaningful, e.g: `minor typos fix in README`
- [x] Detailed description added under "Description of the Changes"
- [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1689)
<!-- Reviewable:end -->
