### PR TITLE
Minor clarification in staking as validators procedures

### DIFF
--- a/modules/architecture/pages/staking.adoc
+++ b/modules/architecture/pages/staking.adoc
@@ -272,7 +272,7 @@ To invoke onchain contracts, use https://foundry-rs.github.io/starknet-foundry/s
 
 | Staking
 | Invoke the staking contract's https://github.com/starkware-libs/starknet-staking/blob/main/docs/spec.md#stake[`stake`^] function
-a| * You should make sure you are xref:responsibilities[running a full node and attesting to blocks] before staking
+a| * You should make sure you are xref:responsibilities[running a fully synchronized node] before staking. Attesting to blocks is only possible starting from the epoch following a successful stake.
 * You must first approve the transfer of the amount of STRK tokens to be staked to the staking contract by invoking the STRK contract's `approve` function
 * `operational_address` should have sufficient funds to pay for attestation transactions
 * `amount` should be equal or greater than the xref:protocol[minimum stake for validators] and denominated in FRI (i.e., 1*10^18^ = 1 STRK)

--- a/modules/architecture/pages/staking.adoc
+++ b/modules/architecture/pages/staking.adoc
@@ -272,11 +272,12 @@ To invoke onchain contracts, use https://foundry-rs.github.io/starknet-foundry/s
 
 | Staking
 | Invoke the staking contract's https://github.com/starkware-libs/starknet-staking/blob/main/docs/spec.md#stake[`stake`^] function
-a| * You should make sure you are xref:responsibilities[running a fully synchronized node] before staking. Attesting to blocks is only possible starting from the epoch following a successful stake.
+a| * You should make sure you are xref:responsibilities[running a fully synchronized node] before staking.
 * You must first approve the transfer of the amount of STRK tokens to be staked to the staking contract by invoking the STRK contract's `approve` function
 * `operational_address` should have sufficient funds to pay for attestation transactions
 * `amount` should be equal or greater than the xref:protocol[minimum stake for validators] and denominated in FRI (i.e., 1*10^18^ = 1 STRK)
 * `commission` should be entered as a percentage with precision, where 10,000 represents 100% (e.g., to set a 5% commission, you enter 500)
+* Attesting to blocks is only possible starting from the epoch following a successful stake
 
 | Claiming rewards
 | Invoke the staking contract's https://github.com/starkware-libs/starknet-staking/blob/main/docs/spec.md#claim_rewards[`claim_rewards`^] function


### PR DESCRIPTION
### Description of the Changes

Clarified a misleading instruction in the staking documentation.
The original text implied that validators must be attesting to blocks **before** staking.
However, this is incorrect - attestation is only possible **after staking is completed and one full epoch has passed**.

**Original line:**

```
a| * You should make sure you are xref:responsibilities[running a full node and attesting to blocks] before staking
```

**Updated line:**

```
a| * You should make sure you are xref:responsibilities[running a fully synchronized node] before staking. Attesting to blocks is only possible starting from the epoch following a successful stake.
```

This change helps avoid confusion for new validators who may attempt attestation too early.

---

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1691/architecture/staking/#staking_as_validators

---

### Check List

* [x] Changes made against main branch and PR does not conflict
* [x] PR title is meaningful
* [x] Detailed description added under "Description of the Changes"
* [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1691)
<!-- Reviewable:end -->
