### PR TITLE
Minor clarifications in staking as delegators procedures

### DIFF
--- a/modules/architecture/pages/staking.adoc
+++ b/modules/architecture/pages/staking.adoc
@@ -326,8 +326,7 @@ The following procedures are only intended for developers who are either interes
 
 | Entering a delegation pool
 | Invoke the delegation pool contract's https://github.com/starkware-libs/starknet-staking/blob/main/docs/spec.md#enter_delegation_pool[`enter_delegation_pool`^] function
-a| * Use this when delegating to a pool **for the first time**
-* `amount` should be denominated in FRI (i.e., 1×10^18^ = 1 STRK)
+a| * `amount` should be denominated in FRI (i.e., 1×10^18^ = 1 STRK)
 * You must first approve the transfer of STRK tokens to the delegation pool contract by invoking the STRK contract’s `approve` function
 
 | Claiming rewards
@@ -336,7 +335,7 @@ a| * Use this when delegating to a pool **for the first time**
 
 | Adding to a delegation pool
 | Invoke the delegation pool contract's https://github.com/starkware-libs/starknet-staking/blob/main/docs/spec.md#add_to_delegation_pool[`add_to_delegation_pool`^] function
-a| * Use this when **adding more tokens** to a pool you have already entered
+a| * Adding to a delegation pool is only possible after entering it using `enter_delegation_pool`
 * `amount` should be denominated in FRI (i.e., 1×10^18^ = 1 STRK)
 * You must first approve the transfer of STRK tokens to the delegation pool contract by invoking the STRK contract’s `approve` function
 

--- a/modules/architecture/pages/staking.adoc
+++ b/modules/architecture/pages/staking.adoc
@@ -326,8 +326,9 @@ The following procedures are only intended for developers who are either interes
 
 | Entering a delegation pool
 | Invoke the delegation pool contract's https://github.com/starkware-libs/starknet-staking/blob/main/docs/spec.md#enter_delegation_pool[`enter_delegation_pool`^] function
-a| * `amount` should be denominated in FRI (i.e., 1*10^18^ = 1 STRK)
-* You must first approve the transfer of STRK tokens to the delegation pool contract by invoking the STRK contract's `approve` function
+a| * Use this when delegating to a pool **for the first time**
+* `amount` should be denominated in FRI (i.e., 1×10^18^ = 1 STRK)
+* You must first approve the transfer of STRK tokens to the delegation pool contract by invoking the STRK contract’s `approve` function
 
 | Claiming rewards
 | Invoke the delegation pool contract's https://github.com/starkware-libs/starknet-staking/blob/main/docs/spec.md#claim_rewards-1[`claim_rewards`^] function
@@ -335,8 +336,9 @@ a| * `amount` should be denominated in FRI (i.e., 1*10^18^ = 1 STRK)
 
 | Adding to a delegation pool
 | Invoke the delegation pool contract's https://github.com/starkware-libs/starknet-staking/blob/main/docs/spec.md#add_to_delegation_pool[`add_to_delegation_pool`^] function
-a| * `amount` should be denominated in FRI (i.e., 1*10^18^ = 1 STRK)
-* You must first approve the transfer of STRK tokens to the delegation pool contract by invoking the STRK contract's `approve` function
+a| * Use this when **adding more tokens** to a pool you have already entered
+* `amount` should be denominated in FRI (i.e., 1×10^18^ = 1 STRK)
+* You must first approve the transfer of STRK tokens to the delegation pool contract by invoking the STRK contract’s `approve` function
 
 | Switching delegation pools
 | Invoke the delegation pool contract's https://github.com/starkware-libs/starknet-staking/blob/main/docs/spec.md#switch_delegation_pool[`switch_delegation_pool`^] function


### PR DESCRIPTION
### Description of the Changes

Clarified the difference between `enter_delegation_pool` and `add_to_delegation_pool` functions in the staking documentation.

* Specified that `enter_delegation_pool` should be used when a user delegates for the **first time** to a pool.
* Explained that `add_to_delegation_pool` is intended for **adding more tokens** after the initial delegation.

These changes aim to eliminate confusion between the two similar-sounding functions and help users avoid mistakes when interacting with the delegation contract.

### PR Preview URL

https://starknet-io.github.io/starknet-docs/pr-1692/architecture/staking/#staking_as_delegators

### Check List

* [x] Changes made against main branch and PR does not conflict
* [x] PR title is meaningful, e.g: `clarify usage of delegation pool entry functions`
* [x] Detailed description added under "Description of the Changes"
* [x] Specific URL(s) added under "PR Preview URL"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1692)
<!-- Reviewable:end -->
