### PR TITLE
Update transactions.adoc

### DIFF
--- a/modules/architecture/pages/transactions.adoc
+++ b/modules/architecture/pages/transactions.adoc
@@ -1,7 +1,7 @@
 = Transactions
 
 == Overview
-Transactions are cryptographically signed instructions from accounts that update the state of the Starknet network. Starknet supports only xref:transaction_types[three types] of transactions, with each type going through the same xref:transaction_lifecycle[lifecycle] to receive its xref:transaction_statuses[execution and finality statuses]. Every transaction that was executed successfully is issued a xref:transaction_receipt[receipt], which includes its statuses, as well as other information about it.
+Transactions are cryptographically signed instructions from accounts that update the state of the Starknet network. Starknet supports only xref:transaction_types[three types] of transactions, with each type going through the same xref:transaction_lifecycle[lifecycle] to receive its xref:transaction_statuses[execution and finality statuses]. Every transaction included in a block is issued a xref:transaction_receipt[receipt], which includes its statuses, as well as other information about it.
 
 .Additional information
 


### PR DESCRIPTION
### Description of the Changes

Edited a sentence saying that a transaction that was executed successfully is issued a receipt, since it implied that only txs with finality status `SUCCEEDED` have receipts, while also `REVERTED` txs have one.

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Please paste the specific URL(s) of the content that this PR addresses here.

### Check List

- [ ] Changes made against main branch and PR does not conflict
- [ ] PR title is meaningful, e.g: `minor typos fix in README`
- [ ] Detailed description added under "Description of the Changes"
- [ ] Specific URL(s) added under "PR Preview URL"


