### PR TITLE
Update attestation window length

### DIFF
--- a/learn/protocol/staking.mdx
+++ b/learn/protocol/staking.mdx
@@ -53,7 +53,7 @@ The following sections describe the details of Starknet's staking protocol. The 
 | Withdrawal security lockup                 | 21 days      | 5 minutes    |
 | Epoch length ($$E$$)                       | 120 blocks   | 231 blocks   |
 | Epoch duration                             | 3600 seconds | 1200 seconds |
-| Attestation window ($$W$$)                 | 30 blocks    | 30 blocks    |
+| Attestation window ($$W$$)                 | 40 blocks    | 40 blocks    |
 | Number of epochs used for latency ($$k$$)  | 1 epoch      | 1 epoch      |
 | Weight of BTC in staking power ($$\alpha$$) | N/A          | 0.25         |
 


### PR DESCRIPTION
Update attestation window length from 30 to 40 blocks to reflect the currently used value on both mainnet and sepolia

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1709)
<!-- Reviewable:end -->
