### PR TITLE
Update Withdrawal security lockup for mainnet

### DIFF
--- a/learn/protocol/staking.mdx
+++ b/learn/protocol/staking.mdx
@@ -50,7 +50,7 @@ The following sections describe the details of Starknet's staking protocol. The 
 | ------------------------------------------ | ------------ | ------------ |
 | Minimum stake for validators               | 20K STRK     | 1 STRK       |
 | Effective inflation coefficient ($$\hat{C}$$) | 1.6%         | 1.6%         |
-| Withdrawal security lockup                 | 21 days      | 5 minutes    |
+| Withdrawal security lockup                 | 7 days      | 5 minutes    |
 | Epoch length ($$E$$)                       | 120 blocks   | 231 blocks   |
 | Epoch duration                             | 3600 seconds | 1200 seconds |
 | Attestation window ($$W$$)                 | 30 blocks    | 30 blocks    |


### PR DESCRIPTION
Update Withdrawal security lockup on mainnet from 21 to 7 days

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/starknet-docs/1711)
<!-- Reviewable:end -->
