### PR TITLE
Add governance docs section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1078,6 +1078,22 @@
             ]
           },
           {
+            "group": "Governance",
+            "pages": [
+              "learn/governance/overview",
+              "learn/governance/voting",
+              "learn/governance/delegation",
+              {
+                "group": "Councils",
+                "pages": [
+                  "learn/governance/security-council",
+                  "learn/governance/monetary-committee"
+                ]
+              },
+              "learn/governance/faqs"
+            ]
+          },
+          {
             "group": "Cheatsheets",
             "pages": [
               {

--- a/docs.json
+++ b/docs.json
@@ -1087,7 +1087,8 @@
                 "group": "Councils",
                 "pages": [
                   "learn/governance/security-council",
-                  "learn/governance/monetary-committee"
+                  "learn/governance/monetary-committee",
+                  "learn/governance/federation-charter"
                 ]
               },
               "learn/governance/faqs"

--- a/learn/governance/delegation.mdx
+++ b/learn/governance/delegation.mdx
@@ -2,51 +2,30 @@
 title: "Delegation"
 ---
 
-Holding STRK tokens gives you a voice in Starknet governance—one vote for every token held. However, not everyone feels qualified to evaluate complex technical proposals. Vote delegation allows token holders to transfer their voting power to informed, professional community members.
+Holding STRK tokens gives you a voice in Starknet governance, one vote for every token held. However, not everyone feels qualified to evaluate complex technical proposals. Vote delegation allows token holders to transfer their voting power to informed, professional community members.
 
 ## Key principles
 
-- Any community member can volunteer to act as a delegate
 - Any token holder can delegate voting power to any delegate
+- Any community member can receive delegation; there is no approval process required to become a delegate
 - Delegates do not need to own tokens themselves
+- Token holders can reassign their delegation whenever they choose
 
 ## Benefits of delegation
 
 - Token holders can participate through democratic representatives
 - Dedicated community members take significant governance roles based on merit and reputation
 
-## 3-Tier Delegate System
-
-The Starknet Foundation has implemented a 3-Tier Delegate System to redistribute 1.7B STRK voting power, incentivizing voting activity while supporting a broader set of ecosystem members.
-
-| Tier | Total Voting Power | Number of Delegates | Power per Delegate |
-| :---- | :---- | :---- | :---- |
-| Tier 1 | 700M STRK (41%) | 20 delegates | 35M STRK |
-| Tier 2 | 600M STRK (35.5%) | 60 delegates | 10M STRK |
-| Tier 3 | 400M STRK (23.5%) | 100 delegates | 4M STRK |
-
-**Notes:**
-
-- Tier membership may change between votes based on delegate activity
-- Builders Council members have transitioned into individual Tier 1 delegates
-- Tier 2 and 3 are composed of community delegates, prioritized by recent activity and external token delegation amounts
-
-For more information on this, see the [Delegated Voting Power Distribution](https://community.starknet.io/t/changes-to-the-delegated-voting-power-by-the-foundation/115407).
-
 ## Becoming a Starknet delegate
 
-Anyone can apply to become a Starknet delegate. [Apply here](https://airtable.com/appQVOyi21x4PVWxz/pag9EE22sK1p2Uzsw/form) to get started.
+Becoming a delegate does not require approval from the Starknet Foundation or any other central body. In practice, a delegate is anyone who receives voting power from token holders.
 
-Applications are assessed based on:
+If you want to act as a delegate, the important steps are:
 
-- Contribution history in the Starknet ecosystem
-- Active participation in governance discussions
-- Technical understanding of the protocol
-- Commitment to delegate responsibilities
-
-If a candidate applies for Tier 1 but is better suited for Tier 2, the application is automatically moved to Tier 2 without resubmission.
-
-**Inactive delegate policy:** Inactive delegates may be automatically demoted to a lower tier or removed from the program. The Starknet Foundation reserves the right to redistribute voting power from inactive delegates.
+- Maintain a public governance profile
+- Participate in governance discussions
+- Review proposals carefully
+- Communicate your reasoning clearly so token holders can decide whether to delegate to you
 
 ## About the delegation agreement
 
@@ -79,3 +58,11 @@ Delegates who choose not to adopt the specific terms are encouraged to clearly d
 **Proactively Communicate** Delegates are encouraged to communicate the rationale behind their votes clearly and accessibly through the Starknet Governance Hub.
 
 **Give Notice When Resigning** Delegates intending to resign should communicate to the community at least seven days in advance, allowing token holders time to reassign their votes before the next vote.
+
+## Starknet Foundation delegate program
+
+The Starknet Foundation also operates a separate delegate program that distributes Foundation-controlled voting power to selected delegates. This program is distinct from permissionless delegation and should not be confused with the core delegation mechanism described above.
+
+If you want to apply to receive Starknet Foundation delegation, use [this application form](https://airtable.com/appQVOyi21x4PVWxz/pag9EE22sK1p2Uzsw/form).
+
+For additional details on the Foundation program and how delegated voting power is distributed, see the [Delegated Voting Power Distribution](https://community.starknet.io/t/changes-to-the-delegated-voting-power-by-the-foundation/115407).

--- a/learn/governance/delegation.mdx
+++ b/learn/governance/delegation.mdx
@@ -1,0 +1,81 @@
+---
+title: "Delegation"
+---
+
+Holding STRK tokens gives you a voice in Starknet governance—one vote for every token held. However, not everyone feels qualified to evaluate complex technical proposals. Vote delegation allows token holders to transfer their voting power to informed, professional community members.
+
+## Key principles
+
+- Any community member can volunteer to act as a delegate
+- Any token holder can delegate voting power to any delegate
+- Delegates do not need to own tokens themselves
+
+## Benefits of delegation
+
+- Token holders can participate through democratic representatives
+- Dedicated community members take significant governance roles based on merit and reputation
+
+## 3-Tier Delegate System
+
+The Starknet Foundation has implemented a 3-Tier Delegate System to redistribute 1.7B STRK voting power, incentivizing voting activity while supporting a broader set of ecosystem members.
+
+| Tier | Total Voting Power | Number of Delegates | Power per Delegate |
+| :---- | :---- | :---- | :---- |
+| Tier 1 | 700M STRK (41%) | 20 delegates | 35M STRK |
+| Tier 2 | 600M STRK (35.5%) | 60 delegates | 10M STRK |
+| Tier 3 | 400M STRK (23.5%) | 100 delegates | 4M STRK |
+
+**Notes:**
+
+- Tier membership may change between votes based on delegate activity
+- Builders Council members have transitioned into individual Tier 1 delegates
+- Tier 2 and 3 are composed of community delegates, prioritized by recent activity and external token delegation amounts
+
+For more information on this, see the [Delegated Voting Power Distribution](https://community.starknet.io/t/changes-to-the-delegated-voting-power-by-the-foundation/115407).
+
+## Becoming a Starknet delegate
+
+Anyone can apply to become a Starknet delegate. [Apply here](https://airtable.com/appQVOyi21x4PVWxz/pag9EE22sK1p2Uzsw/form) to get started.
+
+Applications are assessed based on:
+
+- Contribution history in the Starknet ecosystem
+- Active participation in governance discussions
+- Technical understanding of the protocol
+- Commitment to delegate responsibilities
+
+If a candidate applies for Tier 1 but is better suited for Tier 2, the application is automatically moved to Tier 2 without resubmission.
+
+**Inactive delegate policy:** Inactive delegates may be automatically demoted to a lower tier or removed from the program. The Starknet Foundation reserves the right to redistribute voting power from inactive delegates.
+
+## About the delegation agreement
+
+To promote delegate neutrality pursuant to the [neutrality principle of Starknet](https://hackmd.io/@Elibensasson/ryMelVulp) and enable informed decision-making, the Governance Committee created a template delegation agreement.
+
+Adopting the agreement is optional. Delegation remains a completely permissionless process with no requirement to adopt any legal agreements. The template serves as a tool for delegates and token holders to define their relationship.
+
+Delegates who choose not to adopt the specific terms are encouraged to clearly define their own terms and decision-making processes in their delegate profile.
+
+## Expectations of a delegate
+
+**Be Informed** Delegates should have working knowledge of Starknet and seriously study each proposal to make well-founded, independent decisions that benefit Starknet's long-term vision.
+
+**Participate** Delegates are expected to:
+
+- Engage in community conferences and discussions
+- Answer community questions
+- Vote on proposals
+- Attend monthly governance assemblies
+
+**Act in Good Faith** Delegates shall act in good faith and in the best interests of the Starknet ecosystem by reviewing proposals and evaluating their potential benefit to the entire ecosystem.
+
+**Avoid Conflicts of Interest**
+
+- Take steps to avoid conflicts of interest
+- Disclose compensation related to delegation or governance participation
+- Disclose conflicts in delegate profiles
+- Abstain from votes when conflicts affect ability to vote fairly
+
+**Proactively Communicate** Delegates are encouraged to communicate the rationale behind their votes clearly and accessibly through the Starknet Governance Hub.
+
+**Give Notice When Resigning** Delegates intending to resign should communicate to the community at least seven days in advance, allowing token holders time to reassign their votes before the next vote.

--- a/learn/governance/delegation.mdx
+++ b/learn/governance/delegation.mdx
@@ -37,27 +37,37 @@ Delegates who choose not to adopt the specific terms are encouraged to clearly d
 
 ## Expectations of a delegate
 
-**Be Informed** Delegates should have working knowledge of Starknet and seriously study each proposal to make well-founded, independent decisions that benefit Starknet's long-term vision.
+### Be Informed
 
-**Participate** Delegates are expected to:
+Delegates should have working knowledge of Starknet and seriously study each proposal to make well-founded, independent decisions that benefit Starknet's long-term vision.
+
+### Participate
+
+Delegates are expected to:
 
 - Engage in community conferences and discussions
 - Answer community questions
 - Vote on proposals
 - Attend monthly governance assemblies
 
-**Act in Good Faith** Delegates shall act in good faith and in the best interests of the Starknet ecosystem by reviewing proposals and evaluating their potential benefit to the entire ecosystem.
+### Act in Good Faith
 
-**Avoid Conflicts of Interest**
+Delegates shall act in good faith and in the best interests of the Starknet ecosystem by reviewing proposals and evaluating their potential benefit to the entire ecosystem.
+
+### Avoid Conflicts of Interest
 
 - Take steps to avoid conflicts of interest
 - Disclose compensation related to delegation or governance participation
 - Disclose conflicts in delegate profiles
 - Abstain from votes when conflicts affect ability to vote fairly
 
-**Proactively Communicate** Delegates are encouraged to communicate the rationale behind their votes clearly and accessibly through the Starknet Governance Hub.
+### Proactively Communicate
 
-**Give Notice When Resigning** Delegates intending to resign should communicate to the community at least seven days in advance, allowing token holders time to reassign their votes before the next vote.
+Delegates are encouraged to communicate the rationale behind their votes clearly and accessibly through the Starknet Governance Hub.
+
+### Give Notice When Resigning
+
+Delegates intending to resign should communicate to the community at least seven days in advance, allowing token holders time to reassign their votes before the next vote.
 
 ## Starknet Foundation delegate program
 

--- a/learn/governance/faqs.mdx
+++ b/learn/governance/faqs.mdx
@@ -4,17 +4,19 @@ title: "FAQs"
 
 ### How do I vote?
 
-To vote on Starknet governance proposals, you need to hold STRK tokens (on L1 or staked on L2). Visit the [Governance Hub](https://governance.starknet.io/), connect your wallet, and cast your vote during an active voting period.
+To vote on Starknet governance proposals, you need to hold eligible governance voting power. This currently includes STRK on L1, staked STRK on L2, vSTRK, or delegated voting power. Visit the [Governance Hub](https://governance.starknet.io/), connect your wallet, and cast your vote during an active voting period.
 
 ### How do I become a delegate?
 
-Anyone can apply to become a Starknet delegate regardless of whether they hold STRK tokens. Visit the [delegation page](https://airtable.com/appQVOyi21x4PVWxz/pag9EE22sK1p2Uzsw/form) to apply.
+You do not need approval to become a delegate. Any token holder can delegate voting power to any participant, and delegates do not need to hold STRK tokens themselves.
 
-Delegates are placed into one of three tiers based on their contributions, activity, and external token delegation. See the [Delegation](/learn/governance/delegation) section for details on the tier system.
+Separately, the Starknet Foundation runs a delegate program for applicants who want to receive Foundation delegation. If you want to apply to that program, use [this application form](https://airtable.com/appQVOyi21x4PVWxz/pag9EE22sK1p2Uzsw/form).
+
+See the [Delegation](/learn/governance/delegation) section for the distinction between permissionless delegation and the Foundation delegate program.
 
 ### Is there a minimum amount of STRK needed to vote?
 
-There is no minimum amount of STRK required to vote. Any amount of STRK held on L1 or staked on L2 gives you proportional voting power.
+There is no minimum amount of STRK required to vote. Any amount of eligible voting power gives you proportional voting power, including STRK held on L1, staked STRK on L2, or vSTRK.
 
 ### What is a SNIP?
 

--- a/learn/governance/faqs.mdx
+++ b/learn/governance/faqs.mdx
@@ -1,0 +1,39 @@
+---
+title: "FAQs"
+---
+
+### How do I vote?
+
+To vote on Starknet governance proposals, you need to hold STRK tokens (on L1 or staked on L2). Visit the [Governance Hub](https://governance.starknet.io/), connect your wallet, and cast your vote during an active voting period.
+
+### How do I become a delegate?
+
+Anyone can apply to become a Starknet delegate regardless of whether they hold STRK tokens. Visit the [delegation page](https://airtable.com/appQVOyi21x4PVWxz/pag9EE22sK1p2Uzsw/form) to apply.
+
+Delegates are placed into one of three tiers based on their contributions, activity, and external token delegation. See the [Delegation](/learn/governance/delegation) section for details on the tier system.
+
+### Is there a minimum amount of STRK needed to vote?
+
+There is no minimum amount of STRK required to vote. Any amount of STRK held on L1 or staked on L2 gives you proportional voting power.
+
+### What is a SNIP?
+
+A SNIP (Starknet Improvement Proposal) is a formal document proposing a change to the Starknet protocol. SNIPs are documented in the [SNIPs repository](https://github.com/starknet-io/SNIPs) and discussed in the [Starknet Community Forum](https://community.starknet.io/).
+
+### How do I submit a SNIP?
+
+SNIPs (Starknet Improvement Proposals) are submitted through the [SNIPs repository on GitHub](https://github.com/starknet-io/SNIPs). Draft your proposal following the SNIP template, then post it to the [Community Forum](https://community.starknet.io/) for discussion.
+
+### How often do votes happen?
+
+Votes happen on an as-needed basis, typically aligned with protocol upgrades. There is no fixed schedule, but the updated voting process ensures predictable timelines once a vote is initiated.
+
+For timeline details, see [Voting → Upgrade release process](/learn/governance/voting#upgrade-release-process).
+
+### How can I attend a governance call?
+
+Monthly governance assemblies are open to all Starknet ecosystem members. Follow the [Community Forum](https://community.starknet.io/) and Starknet's social channels for announcements on upcoming calls.
+
+### Where can I discuss proposals before a vote?
+
+The [Starknet Community Forum](https://community.starknet.io/) is the primary venue for technical discussions and deliberation on proposals. Each SNIP is posted there for community feedback before it goes to a vote. You can also engage during monthly governance calls.

--- a/learn/governance/faqs.mdx
+++ b/learn/governance/faqs.mdx
@@ -6,6 +6,10 @@ title: "FAQs"
 
 To vote on Starknet governance proposals, you need to hold eligible governance voting power. This currently includes STRK on L1, staked STRK on L2, vSTRK, or delegated voting power. Visit the [Governance Hub](https://governance.starknet.io/), connect your wallet, and cast your vote during an active voting period.
 
+### Where do governance votes take place?
+
+Governance votes take place on the [Governance Hub](https://governance.starknet.io/), where active proposals are posted for review and voting.
+
 ### How do I become a delegate?
 
 You do not need approval to become a delegate. Any token holder can delegate voting power to any participant, and delegates do not need to hold STRK tokens themselves.

--- a/learn/governance/federation-charter.mdx
+++ b/learn/governance/federation-charter.mdx
@@ -1,0 +1,25 @@
+---
+title: "Federation Charter"
+---
+
+The Federation Charter defines the governance and operational framework for the strkBTC Federation.
+
+In the current bridge model, the Federation is responsible for supporting BTC ↔ strkBTC flows through a federated multisig and associated Starknet bridge infrastructure. The Charter sets out the Federation’s role, guiding principles, operational responsibilities, standards of conduct, and member expectations.
+
+Federation members are responsible for operating signer infrastructure, monitoring bridge activity, verifying deposits and withdrawals, co-signing valid minting and burning transactions, participating in upgrades and testing, and coordinating incident response. Governance and accountability expectations, including member conduct and removal conditions, are defined in the Charter.
+
+## Federation members
+
+The Federation members are:
+
+- Xverse
+- Twinstake
+- NEAR
+- UTXO
+- Luganodes
+- OneKey
+
+For more details, see:
+
+- [Federation Charter](https://drive.google.com/file/d/1pxgcEHzbhpMDzPN5ce0idpdX7A2x46h5/view?usp=sharing)
+- [SNIP-38: strkBTC — Bitcoin on Starknet](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-38.md)

--- a/learn/governance/federation-charter.mdx
+++ b/learn/governance/federation-charter.mdx
@@ -17,7 +17,6 @@ The Federation members are:
 - NEAR
 - UTXO
 - Luganodes
-- OneKey
 
 For more details, see:
 

--- a/learn/governance/monetary-committee.mdx
+++ b/learn/governance/monetary-committee.mdx
@@ -1,0 +1,23 @@
+---
+title: "Monetary Committee"
+---
+
+The Monetary Committee was introduced following the community vote on staking to manage Starknet’s monetary parameters.
+
+## Composition
+
+The committee consists of **four organizations**, each providing an individual who will jointly operate a multi-sig. Each member controls one key.
+
+A **committee administrator** coordinates ongoing operations from an administrative perspective (arranging meetings, organizing votes). This role is procedural, communicative, and ministerial in nature.
+
+## Responsibilities
+
+The committee is responsible for proposing and enacting changes to the Layer 2 token admin contract of the Starknet staking mechanism, including:
+
+1. **Minimum staking amount**
+2. **Yearly inflation cap**
+3. **Withdrawal delay**
+
+Changes require **75% of members** (3 of 4) to send a transaction with the multi-sig.
+
+For complete details, see [SNIP 27 - Monetary Committee Charter.](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-27.md)

--- a/learn/governance/overview.mdx
+++ b/learn/governance/overview.mdx
@@ -1,0 +1,15 @@
+---
+title: "Overview"
+---
+
+Starknet governance is a community-driven framework that enables STRK token holders and delegates to participate in shaping the network’s future.
+
+Through a combination of on-chain voting, community deliberation, and specialized councils, Starknet ensures that protocol upgrades, monetary policy, and security decisions reflect the collective will of its ecosystem.
+
+The governance system operates through several interconnected mechanisms: a voting process for protocol upgrades via SNIPs (Starknet Improvement Proposals), delegation for those who prefer to have informed community members vote on their behalf, and specialized councils that handle security and monetary matters.
+
+## Decentralization roadmap
+
+Starknet has progressed through multiple decentralization phases, each adding new layers of community control and distributed operation.
+
+For complete details on Starknet’s decentralization journey, see the [Starknet Roadmap](https://www.starknet.io/roadmap/).

--- a/learn/governance/security-council.mdx
+++ b/learn/governance/security-council.mdx
@@ -1,0 +1,93 @@
+---
+title: "Security Council"
+---
+
+The Starknet Security Council (SSC) is established to ensure the security and integrity of the Starknet network.
+
+The council's initial focus on staking-related contracts will expand over time to cover all of Starknet's core infrastructure.
+
+## Composition
+
+The Security Council consists of **12 organizations**, each providing multiple signers for multi-signature operations.
+
+Members are selected with a focus on:
+
+- Geographic diversity
+- Organizational diversity
+- Security expertise
+
+## Current members
+
+### [Starkware](https://starkware.co/)
+
+1. `0x2914767E232FD7708ab06bA60dB16c36C555751d`
+2. `3h22Qza9i3UWn2c1r9hFtTtaziw3QFuuRgjxTdG2Dou`
+3. `9LY1VueDTBdhXaLkvuK4ubavV9XrZuvBY1EZ58sY5Xj`
+
+### [Cartridge](https://cartridge.gg/)
+
+1. `0x16aB869E6dEe6eF9068E5cF75C1a5A57981257CD`
+2. `RgZfv9YSkeLk5fb4i4g7H34sKAs9rEBEruTUUYUEhvv`
+3. `BT6z1mVQrALryyjg7eu1mHqoSFbAQXAvPQYDijrJ7dd`
+
+### [Hypernative](https://www.hypernative.io/)
+
+1. `0x10277B1922e56d1B69f4dCe5A35696C791F78cac`
+2. `gc6c4PLLkPZwqoK8HYJx7H9vXZQzaEHA1WpcGi5TZF`
+3. `UrP5osByPodYqJXjGYnBqYbHHGpcGPTgvsxaaDXT8SW`
+
+### Prototech Labs SEZC
+
+1. `0x590Cb94bE977a769d9E7D95D9eff8DeAe82e430C`
+2. `8WvKnVnLEvoebkqGUG9XqGfcEEFQvWcD3ESgPFEqeZf`
+3. `DdpYsWmDptgPqmcRQRXhAPfeRqr4PPminuAjAQ8F1Po`
+
+### Flying Muffins
+
+1. `0xFf713991196F8a9D6838bA82C9Bb3579F8Cc0D90`
+2. `2f11suxb4yyz7LGuU6VR9ChCxhpZkqe9ZLwT3C4DdDq`
+3. `Sbvdph8cv5CxvZWWU1bjAHBJvZZJF7vgiQ72XJrb2Cz`
+
+### Space Duck Ltd
+
+1. `0x7A3a1bE19470919318aAD57ba162891a97e2982E`
+2. `6eWN29BRFbrSQpgbUA6Zy5U7ZrQPZxfoB63dweninJ5`
+3. `HL1Jcxm3qpvhrdY4vMQsN9jxdW97ehqkdpSU4a5sAJh`
+
+### [Focus Tree](https://www.focustree.app/)
+
+1. `0x04D5b12b196a8CADEB2F476F22Ffb1334Ef9F94c`
+2. `YdqKnYZzsAwjaa3NDA4H3p3PeW5WLwsYJxKyocfNZB`
+3. `8BNMKbyxWYyw8FjqPsKrKiDszsVgBVGBXSTCjydKHcs`
+
+### [Herodotus](https://herodotus.dev/)
+
+1. `0x5C7DcaECB4D8e49Ea2487c5Cc23C5131Ddb2252F`
+2. `Fbusbk3jH1VyepYmy1fjyRgGHzNEqeMGb4BCWdBj1ga`
+3. `PkviTZFYKh66Po9gZ6hEyDaRyDTGbHySr4mGnd8bB4y`
+
+### [Karnot](https://karnot.xyz/)
+
+1. `0x0762bCc4D604Aa3B5122C7D6571Cf5368EF3F09c`
+2. `EHrDTfJuoJreR7HzPU85SGGKrKVDJ1NozaEJuf3BR6U`
+3. `93CVmRSEdR8s8J7VptAXu3rRducFCtxQQ6rEerKAqXi`
+
+### [Nethermind](https://www.nethermind.io/)
+
+1. `0xfaECfa5E4180dd55D15396F804Fd00C6dbA233B0`
+2. `4qRiHvT5eJ8UfsacUy6ETmJTcFLfVDhyPZhXqmU2Lvv`
+3. `L53BkiYPZFah5mXAp9yM3bsdf5QDER4usShx54AZFsd`
+
+### [Zellic](https://www.zellic.io/)
+
+1. `0xF6AB8BD99EfE2515C45d6FeE8Ea32738877EFbD8`
+2. `7mcJHWjRCgeR4L7b9LdSrAY46g8XxdJVQUekjAMyYa4`
+3. `6H8ME4iNT8VDwpyTnZJoh43YJc9WjSmaL2qSrk2gQXB`
+
+### [Ready](https://www.ready.co/)
+
+1. `0x7383DDEd70cCCFd99835612C4148fA986e9DE560`
+2. `CZDSeAzGQzF23nLWoP2SGwwnKo5xoK6kQcmjtvRpg3s`
+3. `BALV4LaeiAeLuVbtftzVeaJ3pzAkrbxSnxDN8QKrm7F`
+
+For complete duties, operational flows, eligibility, and phased implementation details, see [SNIP-25: Starknet Security Council (SSC)](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-25.md).

--- a/learn/governance/voting.mdx
+++ b/learn/governance/voting.mdx
@@ -20,7 +20,7 @@ Major upgrades require a SNIP to be submitted before the process begins and invo
 
 | Phase            | Duration       | Activity                                                                                                                                                                        |
 | :--------------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Announcement(\*) | Start          | Voting is announced via social posts and a Community Forum post. SNIP is required before this point.                                                                             |
+| Announcement(\*) | Start          | Voting is announced via social posts and a Community Forum post. SNIP is required before this point.                                                                            |
 | Deliberation     | 2 weeks        | Community deliberates. Voting content is finalized. Upgrade should be deployed on testnet. The commit hash from GitHub is available, and the vote is on a specific commit hash. |
 | Review           | 1 week         | Final review period before voting opens.                                                                                                                                        |
 | Voting           | 1 week         | Community votes. Security Council is involved.                                                                                                                                  |
@@ -68,6 +68,7 @@ The following parties can participate in Starknet governance votes:
 
 - **L1 STRK token holders:** Holders of STRK tokens on Ethereum Layer 1
 - **L2 staked STRK:** STRK tokens staked on Starknet Layer 2
+- **vSTRK Holders:** vSTRK tokens that have been locked
 - **Delegates:** Community members who have received delegated voting power
 
 For more information on delegation, see the [Delegation](/learn/governance/delegation) section.

--- a/learn/governance/voting.mdx
+++ b/learn/governance/voting.mdx
@@ -1,0 +1,87 @@
+---
+title: "Voting"
+---
+
+Starknet governance enables community members to vote on major protocol changes, including network upgrades and policy decisions.
+
+## Upgrade release process
+
+Every Starknet upgrade requires at least one SNIP. A new version of Starknet can include multiple Core SNIPs, each representing a specific protocol change. Voting covers the full version, not individual SNIPs.
+
+You can find SNIPs in the [SNIPs repository on GitHub](https://github.com/starknet-io/SNIPs), with discussion threads in the [Starknet Community Forum](https://community.starknet.io/).
+
+## Voting timeline
+
+The voting process differs depending on whether the upgrade is major, minor, or an emergency.
+
+### Major upgrade
+
+Major upgrades require a SNIP to be submitted before the process begins and involve Security Council review. The timeline is as follows:
+
+| Phase            | Duration       | Activity                                                                                                                                                                        |
+| :--------------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Announcement(\*) | Start          | Voting is announced via social posts and a Community Forum post. SNIP is required before this point.                                                                             |
+| Deliberation     | 2 weeks        | Community deliberates. Voting content is finalized. Upgrade should be deployed on testnet. The commit hash from GitHub is available, and the vote is on a specific commit hash. |
+| Review           | 1 week         | Final review period before voting opens.                                                                                                                                        |
+| Voting           | 1 week         | Community votes. Security Council is involved.                                                                                                                                  |
+| Freeze           | Minimum 7 days | Upgrade should not go live for at least 7 days after voting closes.                                                                                                             |
+| Deployment       | —              | Upgrade is deployed to Mainnet.                                                                                                                                                 |
+
+### Minor upgrade
+
+Minor upgrades follow a shorter timeline. A SNIP is needed but not mandatory before the process starts, and it can be submitted in parallel.
+
+| Phase            | Duration       | Activity                                                                                                                                             |
+| :--------------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Announcement(\*) | Start          | Voting is announced. Upgrade should be on testnet by this time. The commit hash from GitHub is available, and the vote is on a specific commit hash. |
+| Review           | 1 week         | Community reviews the upgrade on testnet.                                                                                                            |
+| Voting           | 1 week         | Community votes.                                                                                                                                     |
+| Freeze           | Minimum 5 days | Upgrade should not go live for at least 5 days after voting closes.                                                                                  |
+| Deployment       | —              | Upgrade is deployed to Mainnet.                                                                                                                      |
+
+### Emergency upgrade
+
+Emergency upgrades (including bug fixes and maintenance) bypass the standard voting process:
+
+- Scope is kept open and flexible
+- Falls under the Security Council’s mandate
+- A post-mortem report is required after the fix
+- After resolution, the community can be polled on whether the change should have been handled as a minor or major upgrade
+
+<Note>
+  For all upgrade types, the announcement (*) includes social posts and a
+  Community Forum post. StarkWare and the Starknet Foundation each designate one
+  person responsible for upgrade communications.
+</Note>
+
+### Upgrade types summary
+
+| Type      | SNIP required                              | Voting period | Minimum freeze | Security Council |
+| :-------- | :----------------------------------------- | :------------ | :------------- | :--------------- |
+| Major     | Yes, before announcement                   | 1 week        | 7 days         | Involved         |
+| Minor     | Yes, but not mandatory before announcement | 1 week        | 5 days         | Not required     |
+| Emergency | No (post-mortem required)                  | None          | None           | Initiates action |
+
+## Eligible voters
+
+The following parties can participate in Starknet governance votes:
+
+- **L1 STRK token holders:** Holders of STRK tokens on Ethereum Layer 1
+- **L2 staked STRK:** STRK tokens staked on Starknet Layer 2
+- **Delegates:** Community members who have received delegated voting power
+
+For more information on delegation, see the [Delegation](/learn/governance/delegation) section.
+
+## Threshold and required quorum
+
+- **Simple majority:** A proposal passes if more than 50% of total votes cast approve it by the end of the voting period
+- **No quorum requirement:** No minimum participation level is required for a valid outcome
+
+## Community participation channels
+
+Everyone can help shape Starknet governance through:
+
+- **Discussions:** Participate in the [Starknet Community Forum](https://community.starknet.io/)
+- **Governance calls:** Join monthly governance calls
+- **Meetups and conferences:** Engage at ecosystem events
+- **Voting:** STRK token holders and delegates vote on major protocol changes.

--- a/learn/governance/voting.mdx
+++ b/learn/governance/voting.mdx
@@ -68,7 +68,7 @@ The following parties can participate in Starknet governance votes:
 
 - **L1 STRK token holders:** Holders of STRK tokens on Ethereum Layer 1
 - **L2 staked STRK:** STRK tokens staked on Starknet Layer 2
-- **vSTRK Holders:** vSTRK tokens that have been locked
+- **vSTRK token holders:** Holders of vSTRK tokens
 - **Delegates:** Community members who have received delegated voting power
 
 For more information on delegation, see the [Delegation](/learn/governance/delegation) section.

--- a/learn/governance/voting.mdx
+++ b/learn/governance/voting.mdx
@@ -4,6 +4,8 @@ title: "Voting"
 
 Starknet governance enables community members to vote on major protocol changes, including network upgrades and policy decisions.
 
+Votes are cast through the [Governance Hub](https://governance.starknet.io/), where active proposals are published for review and voting.
+
 ## Upgrade release process
 
 Every Starknet upgrade requires at least one SNIP. A new version of Starknet can include multiple Core SNIPs, each representing a specific protocol change. Voting covers the full version, not individual SNIPs.


### PR DESCRIPTION
## Summary
- add a new Learn > Governance section between S-two book and Cheatsheets
- add governance overview, voting, delegation, councils, and FAQ pages based on the governance source doc
- keep scope limited to governance docs and navigation

## Testing
- npx mint dev
- verified governance routes return 200 locally