### PR TITLE
Update Cairo versions in chain info cheatsheet

### DIFF
--- a/learn/cheatsheets/chain-info.mdx
+++ b/learn/cheatsheets/chain-info.mdx
@@ -8,10 +8,10 @@ title: "Chain information"
 
 ## Current versions
 
-| Environment | Starknet version | Sierra version | Cairo version  |
-| ----------- | ---------------- | -------------- | -------------- |
-| Mainnet     | 0.14.1           | 1.7.0          | 2.0.0 - 2.13.2 |
-| Sepolia     | 0.14.1           | 1.7.0          | 2.0.0 - 2.13.2 |
+| Environment | Starknet version | Sierra version | Cairo version |
+| --- | --- | --- | --- |
+| Mainnet | 0.14.1 | 1.7.0 | 2.0.0 - 2.16.0 |
+| Sepolia | 0.14.2 | 1.7.0 | 2.0.0 - 2.18.0 |
 
 ## Current limits
 
@@ -25,23 +25,23 @@ title: "Chain information"
   Starting from v0.13.5, resources are denominated in units of L2 gas, L1 gas, and L1 data gas.
 </Note>
 
-| Entity                               | Description                                                                                                                                                                                                                                                                 | Limit                      |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| Block time                           | The maximum amount of time within which a preconfirmed block is closed, if no other limit is met                                                                                                                                                                            | 9.5 seconds                |
-| Block recommended time               | The amount of time after which preconfirmed block is closed, if there are no transactions in the mempool and no transactions being executed ATM                                                                                                                             | 2 seconds                  |
-| Max L2 gas per block                 | The maximum amount of L2 gas that a block can contain<br /><br />**Note:** This limit ensures block production times remains consistent and predictable.                                                                                                                    | 6 \* 10^9                  |
-| Max transactions per block           | The maximum amount of transactions in a single block                                                                                                                                                                                                                        | 500                        |
-| Max L2 gas per transaction           | The maximum number of computational steps, measured in L2 gas, that a transaction can contain when processed on the Starknet network<br /><br />**Note:** This limit is important for ensuring the efficient execution of transactions and preventing potential congestion. | 10^9                       |
-| Max state updates per transaction    | The maximum number of storage updates that a single transaction can generate<br /><br />**Note:** This limit helps maintain network stability and predictable performance.                                                                                                  | 2,490                      |
-| Max number of events per transaction | The maximum number of events that a transaction can emit during its execution                                                                                                                                                                                               | 1,000                      |
-| Max number of data felts per event   | The maximum number of felts that an event can contain in its `data` array                                                                                                                                                                                                   | 300                        |
-| Max number of key felts per event    | The maximum number of felts that an event can contain in its `keys` array                                                                                                                                                                                                   | 50                         |
-| Max L2 gas for `validate`            | The maximum number of computational steps, measured in Cairo steps, for a `validate` function                                                                                                                                                                               | 10^8                       |
-| Max contract bytecode size           | The maximum size of the bytecode or program that a smart contract can have on Starknet                                                                                                                                                                                      | 81,920 felts               |
-| Max contract class size              | The maximum size for the Sierra file of a contract class within Starknet<br /><br />**Note:** This limit is important for ensuring the network's scalability and security.                                                                                                  | 4,089,446 bytes            |
-| IP address limits                    | The amount of contract reads that a single IP address can make (in order to reduce network spam)                                                                                                                                                                            | 200 per min per IP address |
-| Signature length                     | The maximum length of a signature                                                                                                                                                                                                                                           | 4,000 felts                |
-| Calldata length                      | The maximum length of a transaction calldata                                                                                                                                                                                                                                | 5,000 felts                |
+| Entity | Description | Limit |
+| --- | --- | --- |
+| Block time | The maximum amount of time within which a preconfirmed block is closed, if no other limit is met | 9.5 seconds |
+| Block recommended time | The amount of time after which preconfirmed block is closed, if there are no transactions in the mempool and no transactions being executed ATM | 2 seconds |
+| Max L2 gas per block | The maximum amount of L2 gas that a block can contain<br /><br />**Note:** This limit ensures block production times remains consistent and predictable. | 6 \* 10^9 |
+| Max transactions per block | The maximum amount of transactions in a single block | 500 |
+| Max L2 gas per transaction | The maximum number of computational steps, measured in L2 gas, that a transaction can contain when processed on the Starknet network<br /><br />**Note:** This limit is important for ensuring the efficient execution of transactions and preventing potential congestion. | 10^9 |
+| Max state updates per transaction | The maximum number of storage updates that a single transaction can generate<br /><br />**Note:** This limit helps maintain network stability and predictable performance. | 2,490 |
+| Max number of events per transaction | The maximum number of events that a transaction can emit during its execution | 1,000 |
+| Max number of data felts per event | The maximum number of felts that an event can contain in its `data` array | 300 |
+| Max number of key felts per event | The maximum number of felts that an event can contain in its `keys` array | 50 |
+| Max L2 gas for `validate` | The maximum number of computational steps, measured in Cairo steps, for a `validate` function | 10^8 |
+| Max contract bytecode size | The maximum size of the bytecode or program that a smart contract can have on Starknet | 81,920 felts |
+| Max contract class size | The maximum size for the Sierra file of a contract class within Starknet<br /><br />**Note:** This limit is important for ensuring the network's scalability and security. | 4,089,446 bytes |
+| IP address limits | The amount of contract reads that a single IP address can make (in order to reduce network spam) | 200 per min per IP address |
+| Signature length | The maximum length of a signature | 4,000 felts |
+| Calldata length | The maximum length of a transaction calldata | 5,000 felts |
 
 ### Block builtin limits
 
@@ -51,18 +51,18 @@ title: "Chain information"
   For more information, see [the release notes for Starknet version 0.13.6](/learn/cheatsheets/version-notes#starknet_v0_13_6_8_jul_25).
 </Warning>
 
-| Builtin        | Limit      |
-| -------------- | ---------- |
-| Range Check    | 57,142,857 |
-| ECDSA          | 3,000      |
-| Poseidon       | 479,961    |
-| Pedersen       | 493,827    |
-| Bitwise        | 6,861,063  |
-| EC OP          | 6,994      |
-| Keccak         | 9,790      |
+| Builtin | Limit |
+| --- | --- |
+| Range Check | 57,142,857 |
+| ECDSA | 3,000 |
+| Poseidon | 479,961 |
+| Pedersen | 493,827 |
+| Bitwise | 6,861,063 |
+| EC OP | 6,994 |
+| Keccak | 9,790 |
 | Range Check 96 | 71,428,571 |
-| Add Mod        | 16,000,000 |
-| Mul Mod        | 6,622,516  |
+| Add Mod | 16,000,000 |
+| Mul Mod | 6,622,516 |
 
 ## Deprecated features
 
@@ -70,9 +70,9 @@ title: "Chain information"
   A deprecated feature is a feature that is still supported, but support will be removed in a future release of Starknet.
 </Note>
 
-| Name                                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Cairo 0                                     | [Starknet v0.11.0](/learn/cheatsheets/version-notes#version0.11.0) introduces Cairo 1.0 smart contracts.                                                                                                                                                                                                                                                                                                                                                               |
+| Name | Description |
+| --- | --- |
+| Cairo 0 | [Starknet v0.11.0](/learn/cheatsheets/version-notes#version0.11.0) introduces Cairo 1.0 smart contracts. |
 | Transaction signing only over two resources | RPC version 0.8, introduced in Starknet 0.13.5, only supports `v3` transactions that sign over three resources (L1 gas, L2 gas and L1 data gas), removing support for transaction versions `v0`, `v1`, and `v2`, and for `v3` transactions that sign only over two resources (L1 gas and L2 gas).<br /><br />Starting from version v0.14.0, Starknet will stop accepting these transactions altogether, and will only accept `v3` transactions compliant with RPC 0.8. |
 
 ## Unsupported and removed features
@@ -83,15 +83,15 @@ title: "Chain information"
   A removed feature is a feature that has been entirely removed.
 </Note>
 
-| Name                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Starknet CLI             | Support for the Starknet CLI has been removed. Instead use [`Starkli or Starknet Foundry's sncast`](./tools).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| Goerli testnet           | Goerli testnet support was removed April 2, 2024. Sepolia testnet replaces Goerli testnet.<br /><br />Starknet started migrating to Sepolia testnet on November 15th, 2023. For more information on the Goerli deprecation, see [the deprecation announcement on Ethereum's site](https://ethereum.org/nb/developers/docs/networks/#ethereum-testnets).<br /><br />Full nodes, API services, SDKs, and other Starknet developer tools have migrated to Sepolia as well.<br /><br />**Note:** Sepolia's state and history are relatively small. Sepolia [supports declaring classes of CairoZero and Cairo v2.0.0 and higher](/learn/cheatsheets/version-notes).                                                                                                                                                                                                     |
-| Starknet feeder gateway  | The Starknet feeder gateway, a temporary solution for querying the sequencer's state, is being replaced by Starknet full nodes (Pathfinder, Juno, Deoxys, Papyrus) and RPC services. For more information, see [Full nodes and API services](./tools).<br /><br />Support for the feeder gateway queries that are not required for full nodes to synchronize on the state of Starknet will stop according to the following schedule:<br /><br />**Environment** \| **Date**<br />Integration \| 1 November 2023<br />Testnet \| 15 November 2023<br />Mainnet \| 19 December 2023<br /><br />Queries that are required for full nodes to synchronize on the state of Starknet are still supported.<br /><br />For more information, see the Community Forum post [_Feeder Gateway Deprecation_](https://community.starknet.io/t/feeder-gateway-deprecation/100233). |
-| Free L1-\> L2 messaging  | Previously, sending a message from L1 to L2 had an optional fee associated.<br /><br />From [Starknet v0.11.0](/learn/cheatsheets/version-notes#version0.11.0), the fee mechanism is enforced and the ability to send L1-\>L2 messages without the corresponding L2 fee has been removed.<br /><br />See [here](/learn/protocol/messaging#l1-l2-message-fees) for more details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `invoke` transaction v0  | `invoke` transaction v0 has been removed since [Starknet v0.11.0](/learn/cheatsheets/version-notes#version0.11.0).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `declare` transaction v0 | `declare` transaction v0 has been removed since [Starknet v0.11.0](/learn/cheatsheets/version-notes#version0.11.0).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `deploy` transaction     | The `deploy` transaction has been removed since [Starknet v0.10.3](/learn/cheatsheets/version-notes#version0.10.3).<br /><br />To deploy new contract instances, you can use the [`deploy system call`](https://book.cairo-lang.org/appendix-08-system-calls.html#deploy).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Name | Description |
+| --- | --- |
+| Starknet CLI | Support for the Starknet CLI has been removed. Instead use [`Starkli or Starknet Foundry's sncast`](./tools). |
+| Goerli testnet | Goerli testnet support was removed April 2, 2024. Sepolia testnet replaces Goerli testnet.<br /><br />Starknet started migrating to Sepolia testnet on November 15th, 2023. For more information on the Goerli deprecation, see [the deprecation announcement on Ethereum's site](https://ethereum.org/nb/developers/docs/networks/#ethereum-testnets).<br /><br />Full nodes, API services, SDKs, and other Starknet developer tools have migrated to Sepolia as well.<br /><br />**Note:** Sepolia's state and history are relatively small. Sepolia [supports declaring classes of CairoZero and Cairo v2.0.0 and higher](/learn/cheatsheets/version-notes). |
+| Starknet feeder gateway | The Starknet feeder gateway, a temporary solution for querying the sequencer's state, is being replaced by Starknet full nodes (Pathfinder, Juno, Deoxys, Papyrus) and RPC services. For more information, see [Full nodes and API services](./tools).<br /><br />Support for the feeder gateway queries that are not required for full nodes to synchronize on the state of Starknet will stop according to the following schedule:<br /><br />**Environment** \| **Date**<br />Integration \| 1 November 2023<br />Testnet \| 15 November 2023<br />Mainnet \| 19 December 2023<br /><br />Queries that are required for full nodes to synchronize on the state of Starknet are still supported.<br /><br />For more information, see the Community Forum post [_Feeder Gateway Deprecation_](https://community.starknet.io/t/feeder-gateway-deprecation/100233). |
+| Free L1-\> L2 messaging | Previously, sending a message from L1 to L2 had an optional fee associated.<br /><br />From [Starknet v0.11.0](/learn/cheatsheets/version-notes#version0.11.0), the fee mechanism is enforced and the ability to send L1-\>L2 messages without the corresponding L2 fee has been removed.<br /><br />See [here](/learn/protocol/messaging#l1-l2-message-fees) for more details. |
+| `invoke` transaction v0 | `invoke` transaction v0 has been removed since [Starknet v0.11.0](/learn/cheatsheets/version-notes#version0.11.0). |
+| `declare` transaction v0 | `declare` transaction v0 has been removed since [Starknet v0.11.0](/learn/cheatsheets/version-notes#version0.11.0). |
+| `deploy` transaction | The `deploy` transaction has been removed since [Starknet v0.10.3](/learn/cheatsheets/version-notes#version0.10.3).<br /><br />To deploy new contract instances, you can use the [`deploy system call`](https://book.cairo-lang.org/appendix-08-system-calls.html#deploy). |
 
 ## Important addresses
 
@@ -99,90 +99,90 @@ title: "Chain information"
 
 #### Mainnet
 
-|                         |                                            |
-| ----------------------- | ------------------------------------------ |
-| Sequencer base URL      | alpha-mainnet.starknet.io                  |
-| Core contract           | 0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4 |
+|  |  |
+| --- | --- |
+| Sequencer base URL | alpha-mainnet.starknet.io |
+| Core contract | 0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4 |
 | SHARP verifier contract | 0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60 |
 
 #### Sepolia
 
-|                         |                                            |
-| ----------------------- | ------------------------------------------ |
-| Sequencer base URL      | alpha-sepolia.starknet.io                  |
-| Core contract           | 0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057 |
+|  |  |
+| --- | --- |
+| Sequencer base URL | alpha-sepolia.starknet.io |
+| Core contract | 0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057 |
 | SHARP verifier contract | 0x07ec0D28e50322Eb0C159B9090ecF3aeA8346DFe |
 
 ### Tokens
 
 #### Mainnet
 
-|                |                                                                    |
-| -------------- | ------------------------------------------------------------------ |
-| STRK contract  | 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d |
-| ETH contract   | 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7 |
+|  |  |
+| --- | --- |
+| STRK contract | 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d |
+| ETH contract | 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7 |
 | vSTRK contract | 0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f |
 
 #### Sepolia
 
-|                |                                                                    |
-| -------------- | ------------------------------------------------------------------ |
-| STRK contract  | 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d |
-| ETH contract   | 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7 |
+|  |  |
+| --- | --- |
+| STRK contract | 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d |
+| ETH contract | 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7 |
 | vSTRK contract | 0x035c332b8de00874e702b4831c84b22281fb3246f714475496d74e644f35d492 |
 
 ### StarkGate
 
 #### Mainnet
 
-|                                 |                                                                                           |
-| ------------------------------- | ----------------------------------------------------------------------------------------- |
-| StarkgateManager contract       | 0x0c5aE94f8939182F2D06097025324D1E537d5B60                                                |
-| StarkgateRegistry contract      | 0x1268cc171c54F2000402DfF20E93E60DF4c96812                                                |
-| L1 StarknetTokenBridge contract | 0xF5b6Ee2CAEb6769659f6C091D209DfdCaF3F69Eb                                                |
-| L2 StarknetTokenBridge contract | 0x0616757a151c21f9be8775098d591c2807316d992bbc3bb1a5c1821630589256                        |
-| Bridged tokens                  | https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json |
+|  |  |
+| --- | --- |
+| StarkgateManager contract | 0x0c5aE94f8939182F2D06097025324D1E537d5B60 |
+| StarkgateRegistry contract | 0x1268cc171c54F2000402DfF20E93E60DF4c96812 |
+| L1 StarknetTokenBridge contract | 0xF5b6Ee2CAEb6769659f6C091D209DfdCaF3F69Eb |
+| L2 StarknetTokenBridge contract | 0x0616757a151c21f9be8775098d591c2807316d992bbc3bb1a5c1821630589256 |
+| Bridged tokens | [https://github.com/starknet-io/starknet-addresses/blob/master/bridged\_tokens/mainnet.json](https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json) |
 
 #### Sepolia
 
-|                |                                                                                           |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| Bridged tokens | https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/sepolia.json |
+|  |  |
+| --- | --- |
+| Bridged tokens | [https://github.com/starknet-io/starknet-addresses/blob/master/bridged\_tokens/sepolia.json](https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/sepolia.json) |
 
 ### Staking
 
 #### Mainnet
 
-|                             |                                                                    |
-| --------------------------- | ------------------------------------------------------------------ |
-| Staking contract            | 0x00ca1702e64c81d9a07b86bd2c540188d92a2c73cf5cc0e508d949015e7e84a7 |
-| L1 Reward supplier contract | 0xCa1406D57eD09947E68DE121316C87113fBE9ff5                         |
+|  |  |
+| --- | --- |
+| Staking contract | 0x00ca1702e64c81d9a07b86bd2c540188d92a2c73cf5cc0e508d949015e7e84a7 |
+| L1 Reward supplier contract | 0xCa1406D57eD09947E68DE121316C87113fBE9ff5 |
 | L2 Reward supplier contract | 0x009035556d1ee136e7722ae4e78f92828553a45eed3bc9b2aba90788ec2ca112 |
-| Mint manager contract       | 0xCa14076A3cec95448BaD179cc19B351A4204B88B                         |
-| Minting curve contract      | 0x00ca1705e74233131dbcdee7f1b8d2926bf262168c7df339004b3f46015b6984 |
-| Attestation contract        | 0x10398fe631af9ab2311840432d507bf7ef4b959ae967f1507928f5afe888a99  |
+| Mint manager contract | 0xCa14076A3cec95448BaD179cc19B351A4204B88B |
+| Minting curve contract | 0x00ca1705e74233131dbcdee7f1b8d2926bf262168c7df339004b3f46015b6984 |
+| Attestation contract | 0x10398fe631af9ab2311840432d507bf7ef4b959ae967f1507928f5afe888a99 |
 
-| **Stakable tokens** |                                                                    |
-| :------------------ | :----------------------------------------------------------------- |
-| STRK                | 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d |
-| WBTC                | 0x03fe2b97c1fd336e750087d68b9b867997fd64a2661ff3ca5a7c771641e8e7ac |
-| SolvBTC             | 0x0593e034dda23eea82d2ba9a30960ed42cf4a01502cc2351dc9b9881f9931a68 |
-| tBTC                | 0x04daa17763b286d1e59b97c283c0b8c949994c361e426a28f743c67bdfe9a32f |
-| LBTC                | 0x036834a40984312f7f7de8d31e3f6305b325389eaeea5b1c0664b2fb936461a4 |
+| **Stakable tokens** |  |
+| :-- | :-- |
+| STRK | 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d |
+| WBTC | 0x03fe2b97c1fd336e750087d68b9b867997fd64a2661ff3ca5a7c771641e8e7ac |
+| SolvBTC | 0x0593e034dda23eea82d2ba9a30960ed42cf4a01502cc2351dc9b9881f9931a68 |
+| tBTC | 0x04daa17763b286d1e59b97c283c0b8c949994c361e426a28f743c67bdfe9a32f |
+| LBTC | 0x036834a40984312f7f7de8d31e3f6305b325389eaeea5b1c0664b2fb936461a4 |
 
 #### Sepolia
 
-|                             |                                                                    |
-| --------------------------- | ------------------------------------------------------------------ |
-| Staking contract            | 0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1 |
-| L1 Reward supplier contract | 0xE58d25681B9d290D60e4d7f379a05d5BFD973fFB                         |
+|  |  |
+| --- | --- |
+| Staking contract | 0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1 |
+| L1 Reward supplier contract | 0xE58d25681B9d290D60e4d7f379a05d5BFD973fFB |
 | L2 Reward supplier contract | 0x02ebbebb8ceb2e07f30a5088f5849afd4f908f04f3f9c97c694e5d83d2a7cc61 |
-| Mint manager contract       | 0x648D1B35a932F5189e7ff97b2F795E03734DE4ce                         |
-| Minting curve contract      | 0x06043928ca93cff6d6f39378ba391d7152eea707bdd624c1b2074e71af2abaca |
-| Attestation contract        | 0x03f32e152b9637c31bfcf73e434f78591067a01ba070505ff6ee195642c9acfb |
+| Mint manager contract | 0x648D1B35a932F5189e7ff97b2F795E03734DE4ce |
+| Minting curve contract | 0x06043928ca93cff6d6f39378ba391d7152eea707bdd624c1b2074e71af2abaca |
+| Attestation contract | 0x03f32e152b9637c31bfcf73e434f78591067a01ba070505ff6ee195642c9acfb |
 
-| **Stakable tokens** |                                                                    |
-| :------------------ | :----------------------------------------------------------------- |
-| STRK                | 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d |
-| TestBTC1 token      | 0x044ad07751ad782288413c7db42c48e1c4f6195876bca3b6caef449bb4fb8d36 |
-| TestBTC2 token      | 0x07e97477601e5606359303cf50c050fd3ba94f66bd041f4ed504673ba2b81696 |
+| **Stakable tokens** |  |
+| :-- | :-- |
+| STRK | 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d |
+| TestBTC1 token | 0x044ad07751ad782288413c7db42c48e1c4f6195876bca3b6caef449bb4fb8d36 |
+| TestBTC2 token | 0x07e97477601e5606359303cf50c050fd3ba94f66bd041f4ed504673ba2b81696 |


### PR DESCRIPTION
## Summary
This update revises the Cairo versions listed for Mainnet and Sepolia in the chain information cheatsheet.

## Changes
- Updated Cairo version range for Mainnet to 2.0.0 - 2.16.0
- Updated Cairo version range for Sepolia to 2.0.0 - 2.18.0
- Modified Starknet version for Sepolia to 0.14.2
- Adjusted table formatting for improved readability

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/starkware-9575960b/starkware-9575960b/editor/update_0_14_2_status-before-mainnet-upgrade?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->