### PR TITLE
Starknet version and Cairo compatibility updates

### DIFF
--- a/learn/cheatsheets/chain-info.mdx
+++ b/learn/cheatsheets/chain-info.mdx
@@ -10,7 +10,7 @@ title: "Chain information"
 
 | Environment | Starknet version | Sierra version | Cairo version |
 | --- | --- | --- | --- |
-| Mainnet | 0.14.1 | 1.7.0 | 2.0.0 - 2.16.0 |
+| Mainnet | 0.14.2 | 1.7.0 | 2.0.0 - 2.18.0 |
 | Sepolia | 0.14.2 | 1.7.0 | 2.0.0 - 2.18.0 |
 
 ## Current limits
@@ -31,7 +31,7 @@ title: "Chain information"
 | Block recommended time | The amount of time after which preconfirmed block is closed, if there are no transactions in the mempool and no transactions being executed ATM | 2 seconds |
 | Max L2 gas per block | The maximum amount of L2 gas that a block can contain<br /><br />**Note:** This limit ensures block production times remains consistent and predictable. | 6 \* 10^9 |
 | Max transactions per block | The maximum amount of transactions in a single block | 500 |
-| Max L2 gas per transaction | The maximum number of computational steps, measured in L2 gas, that a transaction can contain when processed on the Starknet network<br /><br />**Note:** This limit is important for ensuring the efficient execution of transactions and preventing potential congestion. | 10^9 |
+| Max L2 gas per transaction | The maximum number of computational steps, measured in L2 gas, that a transaction can contain when processed on the Starknet network<br /><br />**Note:** This limit is important for ensuring the efficient execution of transactions and preventing potential congestion. | 1.1\*10^9 |
 | Max state updates per transaction | The maximum number of storage updates that a single transaction can generate<br /><br />**Note:** This limit helps maintain network stability and predictable performance. | 2,490 |
 | Max number of events per transaction | The maximum number of events that a transaction can emit during its execution | 1,000 |
 | Max number of data felts per event | The maximum number of felts that an event can contain in its `data` array | 300 |

--- a/learn/cheatsheets/compatibility.mdx
+++ b/learn/cheatsheets/compatibility.mdx
@@ -10,13 +10,13 @@ title: "Compatibility tables"
 
 ## Starknet versions
 
-|            | Starknet 0.14.1 | Starknet 0.14.0 | Starknet 0.13.5 | Starknet 0.13.3 |
-| ---------- | --------------- | --------------- | --------------- | --------------- |
-| RPC        | 0.10            | 0.9             | 0.8             | 0.7             |
-| Cairo      | 2.13.2          | 2.12.0          | 2.11.0          | 2.9.0           |
-| Sierra     | 1.7.0           | 1.7.0           | 1.7.0           | 1.6.0           |
-| Pathfinder | 0.21.3          | 0.18.0          | 0.16.2          | 0.15.1          |
-| Juno       | 0.15.15         | 0.15.1          | 0.14.2          | 0.12.4          |
+|  | Starknet 0.14.2 | Starknet 0.14.1 | Starknet 0.14.0 | Starknet 0.13.5 |
+| --- | --- | :-- | :-- | :-- |
+| RPC | 0.10.2 | 0.10 | 0.9 | 0.8 |
+| Cairo | 2.18.0 | 2.13.2 | 2.12.0 | 2.11.0 |
+| Sierra | 1.7.0 | 1.7.0 | 1.7.0 | 1.7.0 |
+| Pathfinder | 0.22.2 | 0.21.3 | 0.18.0 | 0.16.2 |
+| Juno | 0.15.22 | 0.15.15 | 0.15.1 | 0.14.2 |
 
 ## Starknet RPC versions
 
@@ -26,18 +26,17 @@ title: "Compatibility tables"
   For older versions, the version specified is the last recommended version of the tool that worked with the respective API version.
 </Note>
 
-|                  | RPC 0.10    | RPC 0.9      | RPC 0.8 | RPC 0.7 |
-| ---------------- | ----------- | ------------ | ------- | ------- |
-| Pathfinder       | 0.21        | 0.18.0       | 0.16.2  | 0.11.0  |
-| Juno             | 0.15.11     | 0.15.1       | 0.14.2  | 0.11.0  |
-| Starknet Foundry | 0.53        | 0.48.0       | 0.39.0  | 0.27.0  |
-| Starknet Devnet  | 0.7         | 0.5.0-rc.4   | 0.3.0   | 0.1.2   |
-| starknet.js      | 8.9.0       | 8.0.0-beta.4 | 7.0.1   | 6.11.0  |
-| starknet.py      | 0.29.0      | 0.28.0-rc.3  | 0.26.0  | 0.21.0  |
-| starknet-rs      | 0.18.0      | 0.17.2-rc.2  | 0.14.0  | 0.11.0  |
-| starknet.go      | 0.18        | 0.17         | 0.8     | 0.7     |
-| starknet-jvm     | 0.17.0-rc.0 | 0.16.0-rc.0  | 0.14.0  | 0.11.0  |
-| starknet.swift   | 0.15.0      | v0.14.0-rc.1 | 0.13.1  | 0.9.0   |
+|  | RPC  0.10.2 | RPC 0.10 | RPC 0.9 | RPC 0.8 |
+| --- | --- | :-- | :-- | :-- |
+| Pathfinder | 0.22.2 | 0.21 | 0.18.0 | 0.16.2 |
+| Juno | 0.15.22 | 0.15.11 | 0.15.1 | 0.14.2 |
+| Starknet Foundry | 0.59.0 | 0.53 | 0.48.0 | 0.39.0 |
+| Starknet Devnet | 0.8.0 | 0.7 | 0.5.0-rc.4 | 0.3.0 |
+| starknet.js | 10.0.0 | 8.9.0 | 8.0.0-beta.4 | 7.0.1 |
+| starknet.py | 0.30.0 | 0.29.0 | 0.28.0-rc.3 | 0.26.0 |
+| starknet-rs | 0.19.0 | 0.18.0 | 0.17.2-rc.2 | 0.14.0 |
+| starknet-jvm | 0.18.0 | 0.17.0-rc.0 | 0.16.0-rc.0 | 0.14.0 |
+| starknet.swift | WIP | 0.15.0 | v0.14.0-rc.1 | 0.13.1 |
 
 ## Cairo
 
@@ -49,7 +48,7 @@ title: "Compatibility tables"
   For Starkli, the version specified is the version that can declare and deploy contracts written in the respective Cairo version.
 </Note>
 
-|                  | Cairo 2.13.x | Cairo 2.12.x | Cairo 2.11.x | Cairo 2.10.x |
-| ---------------- | ------------ | ------------ | ------------ | ------------ |
-| Starknet Foundry | 0.53         | 0.48.0       | 0.38.3       | 0.38.3       |
-| Starknet Devnet  | 0.7          | 0.5.0-rc.4   | 0.3.0        | 0.3.0-rc.1   |
+|  | Cairo 2.13.x | Cairo 2.12.x | Cairo 2.11.x | Cairo 2.10.x |
+| --- | --- | --- | --- | --- |
+| Starknet Foundry | 0.53 | 0.48.0 | 0.38.3 | 0.38.3 |
+| Starknet Devnet | 0.7 | 0.5.0-rc.4 | 0.3.0 | 0.3.0-rc.1 |


### PR DESCRIPTION
## Summary
This update revises the Starknet version information, including the latest Cairo compatibility range and an updated compatibility table for various Starknet versions.

## Changes
* Updated Mainnet and Sepolia Starknet versions to 0.14.2 in `chain-info.mdx`
* Extended Cairo version range to 2.0.0 - 2.18.0 in `chain-info.mdx`
* Updated the compatibility table in `compatibility.mdx` to reflect Starknet 0.14.2 and its corresponding RPC version

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/starkware-9575960b/starkware-9575960b/editor/add-0-14-2-details?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->