### PR TITLE
ci: add docs discovery health check

### DIFF
--- a/.github/workflows/discovery-health-check.yml
+++ b/.github/workflows/discovery-health-check.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/discovery-health-check.yml
+++ b/.github/workflows/discovery-health-check.yml
@@ -1,0 +1,32 @@
+name: discovery-health-check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * 1"
+  pull_request:
+    paths:
+      - scripts/check_discovery_endpoints.py
+      - .github/workflows/discovery-health-check.yml
+
+concurrency:
+  group: discovery-health-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Check discovery endpoints
+        run: python3 scripts/check_discovery_endpoints.py

--- a/.github/workflows/llms-check.yml
+++ b/.github/workflows/llms-check.yml
@@ -42,4 +42,4 @@ jobs:
           python-version: "3.11"
 
       - name: Validate llms.txt
-        run: python scripts/validate_llms_txt.py
+        run: python3 scripts/validate_llms_txt.py

--- a/scripts/check_discovery_endpoints.py
+++ b/scripts/check_discovery_endpoints.py
@@ -10,7 +10,9 @@ surface that agents and crawlers actually fetch.
 from __future__ import annotations
 
 import argparse
+import random
 import sys
+import time
 from dataclasses import dataclass
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -19,13 +21,15 @@ from urllib.request import Request, urlopen
 DEFAULT_BASE_URL = "https://docs.starknet.io"
 TIMEOUT_SECONDS = 15
 USER_AGENT = "starknet-docs-discovery-check/1.0"
+MAX_ATTEMPTS = 4
+RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
 
 
 @dataclass(frozen=True)
 class Response:
     url: str
     status: int
-    headers: dict[str, str]
+    headers: dict[str, list[str]]
     body: str
 
 
@@ -34,19 +38,42 @@ def fail(message: str) -> None:
     sys.exit(1)
 
 
+def collect_headers(headers: object) -> dict[str, list[str]]:
+    collected: dict[str, list[str]] = {}
+    for key, value in headers.items():
+        collected.setdefault(key.lower(), []).append(value)
+    return collected
+
+
+def retry_delay_seconds(attempt: int) -> float:
+    return min(2 ** (attempt - 1), 8) + random.uniform(0, 0.25)
+
+
 def fetch(url: str, *, method: str = "GET") -> Response:
     request = Request(url, method=method, headers={"User-Agent": USER_AGENT})
-    try:
-        with urlopen(request, timeout=TIMEOUT_SECONDS) as response:
-            body = response.read().decode("utf-8", errors="replace")
-            headers = {key.lower(): value for key, value in response.headers.items()}
-            return Response(url=url, status=response.status, headers=headers, body=body)
-    except HTTPError as error:
-        body = error.read().decode("utf-8", errors="replace")
-        headers = {key.lower(): value for key, value in error.headers.items()}
-        return Response(url=url, status=error.code, headers=headers, body=body)
-    except URLError as error:
-        fail(f"failed to fetch {url}: {error.reason}")
+    last_error: str | None = None
+
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            with urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+                body = response.read().decode("utf-8", errors="replace")
+                headers = collect_headers(response.headers)
+                return Response(url=url, status=response.status, headers=headers, body=body)
+        except HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")
+            headers = collect_headers(error.headers)
+            if error.code not in RETRYABLE_STATUSES or attempt == MAX_ATTEMPTS:
+                return Response(url=url, status=error.code, headers=headers, body=body)
+            last_error = f"HTTP {error.code}"
+        except URLError as error:
+            last_error = str(error.reason)
+            if attempt == MAX_ATTEMPTS:
+                fail(f"failed to fetch {url} after {MAX_ATTEMPTS} attempts: {last_error}")
+
+        print(f"retrying {url} after attempt {attempt}/{MAX_ATTEMPTS}: {last_error}")
+        time.sleep(retry_delay_seconds(attempt))
+
+    fail(f"failed to fetch {url}: {last_error}")
 
 
 def assert_status(response: Response, expected: int = 200) -> None:
@@ -55,7 +82,7 @@ def assert_status(response: Response, expected: int = 200) -> None:
 
 
 def assert_text_content(response: Response) -> None:
-    content_type = response.headers.get("content-type", "")
+    content_type = response.headers.get("content-type", [""])[0]
     if "text/" not in content_type and "xml" not in content_type:
         fail(f"{response.url} returned unexpected content-type: {content_type!r}")
 
@@ -77,8 +104,8 @@ def check_homepage_headers(base_url: str) -> None:
     response = fetch(f"{base_url}/", method="HEAD")
     assert_status(response)
 
-    link_header = response.headers.get("link", "")
-    llms_header = response.headers.get("x-llms-txt", "")
+    link_header = ", ".join(response.headers.get("link", []))
+    llms_header = response.headers.get("x-llms-txt", [""])[0]
     if 'rel="llms-txt"' not in link_header:
         fail(f"{base_url}/ is missing rel=\"llms-txt\" Link header")
     if 'rel="llms-full-txt"' not in link_header:

--- a/scripts/check_discovery_endpoints.py
+++ b/scripts/check_discovery_endpoints.py
@@ -15,6 +15,7 @@ import sys
 import time
 from dataclasses import dataclass
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 
@@ -82,7 +83,8 @@ def assert_status(response: Response, expected: int = 200) -> None:
 
 
 def assert_text_content(response: Response) -> None:
-    content_type = response.headers.get("content-type", [""])[0]
+    content_type = str(response.headers.get("content-type", [""])[0])
+    content_type = content_type.split(";", 1)[0].strip().lower()
     if "text/" not in content_type and "xml" not in content_type:
         fail(f"{response.url} returned unexpected content-type: {content_type!r}")
 
@@ -121,6 +123,9 @@ def main() -> None:
     args = parser.parse_args()
 
     base_url = args.base_url.rstrip("/")
+    parsed_base_url = urlparse(base_url)
+    if parsed_base_url.scheme not in {"http", "https"} or not parsed_base_url.netloc:
+        fail("--base-url must be an absolute http:// or https:// URL")
 
     checks = [
         ("/llms.txt", "# Starknet Documentation"),

--- a/scripts/check_discovery_endpoints.py
+++ b/scripts/check_discovery_endpoints.py
@@ -129,6 +129,13 @@ def main() -> None:
     parsed_base_url = urlparse(base_url)
     if parsed_base_url.scheme not in {"http", "https"} or not parsed_base_url.netloc:
         fail("--base-url must be an absolute http:// or https:// URL")
+    if (
+        parsed_base_url.path
+        or parsed_base_url.params
+        or parsed_base_url.query
+        or parsed_base_url.fragment
+    ):
+        fail("--base-url must be an origin URL: scheme://host[:port]")
 
     checks = [
         ("/llms.txt", "# Starknet Documentation"),

--- a/scripts/check_discovery_endpoints.py
+++ b/scripts/check_discovery_endpoints.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import random
+import re
 import sys
 import time
 from dataclasses import dataclass
@@ -83,10 +84,12 @@ def assert_status(response: Response, expected: int = 200) -> None:
 
 
 def assert_text_content(response: Response) -> None:
-    content_type = str(response.headers.get("content-type", [""])[0])
-    content_type = content_type.split(";", 1)[0].strip().lower()
-    if "text/" not in content_type and "xml" not in content_type:
-        fail(f"{response.url} returned unexpected content-type: {content_type!r}")
+    content_types = response.headers.get("content-type", [""])
+    for raw_content_type in content_types:
+        content_type = str(raw_content_type).split(";", 1)[0].strip().lower()
+        if "text/" in content_type or "xml" in content_type:
+            return
+    fail(f"{response.url} returned unexpected content-type: {content_types!r}")
 
 
 def assert_body_contains(response: Response, needle: str) -> None:
@@ -108,9 +111,9 @@ def check_homepage_headers(base_url: str) -> None:
 
     link_header = ", ".join(response.headers.get("link", []))
     llms_header = response.headers.get("x-llms-txt", [""])[0]
-    if 'rel="llms-txt"' not in link_header:
+    if not re.search(r"""rel\s*=\s*["']llms-txt["']""", link_header, flags=re.I):
         fail(f"{base_url}/ is missing rel=\"llms-txt\" Link header")
-    if 'rel="llms-full-txt"' not in link_header:
+    if not re.search(r"""rel\s*=\s*["']llms-full-txt["']""", link_header, flags=re.I):
         fail(f"{base_url}/ is missing rel=\"llms-full-txt\" Link header")
     if llms_header != "/llms.txt":
         fail(f"{base_url}/ has unexpected x-llms-txt header: {llms_header!r}")

--- a/scripts/check_discovery_endpoints.py
+++ b/scripts/check_discovery_endpoints.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Check live discovery endpoints for docs.starknet.io.
+
+This complements validate_llms_txt.py: the local validator checks repository
+format and link integrity, while this script checks the deployed discovery
+surface that agents and crawlers actually fetch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_BASE_URL = "https://docs.starknet.io"
+TIMEOUT_SECONDS = 15
+USER_AGENT = "starknet-docs-discovery-check/1.0"
+
+
+@dataclass(frozen=True)
+class Response:
+    url: str
+    status: int
+    headers: dict[str, str]
+    body: str
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def fetch(url: str, *, method: str = "GET") -> Response:
+    request = Request(url, method=method, headers={"User-Agent": USER_AGENT})
+    try:
+        with urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            headers = {key.lower(): value for key, value in response.headers.items()}
+            return Response(url=url, status=response.status, headers=headers, body=body)
+    except HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        headers = {key.lower(): value for key, value in error.headers.items()}
+        return Response(url=url, status=error.code, headers=headers, body=body)
+    except URLError as error:
+        fail(f"failed to fetch {url}: {error.reason}")
+
+
+def assert_status(response: Response, expected: int = 200) -> None:
+    if response.status != expected:
+        fail(f"{response.url} returned HTTP {response.status}, expected {expected}")
+
+
+def assert_text_content(response: Response) -> None:
+    content_type = response.headers.get("content-type", "")
+    if "text/" not in content_type and "xml" not in content_type:
+        fail(f"{response.url} returned unexpected content-type: {content_type!r}")
+
+
+def assert_body_contains(response: Response, needle: str) -> None:
+    if needle not in response.body:
+        fail(f"{response.url} does not contain expected text: {needle!r}")
+
+
+def check_endpoint(base_url: str, path: str, expected_text: str) -> None:
+    response = fetch(f"{base_url}{path}")
+    assert_status(response)
+    assert_text_content(response)
+    assert_body_contains(response, expected_text)
+    print(f"OK {path}")
+
+
+def check_homepage_headers(base_url: str) -> None:
+    response = fetch(f"{base_url}/", method="HEAD")
+    assert_status(response)
+
+    link_header = response.headers.get("link", "")
+    llms_header = response.headers.get("x-llms-txt", "")
+    if 'rel="llms-txt"' not in link_header:
+        fail(f"{base_url}/ is missing rel=\"llms-txt\" Link header")
+    if 'rel="llms-full-txt"' not in link_header:
+        fail(f"{base_url}/ is missing rel=\"llms-full-txt\" Link header")
+    if llms_header != "/llms.txt":
+        fail(f"{base_url}/ has unexpected x-llms-txt header: {llms_header!r}")
+    print("OK homepage discovery headers")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    args = parser.parse_args()
+
+    base_url = args.base_url.rstrip("/")
+
+    checks = [
+        ("/llms.txt", "# Starknet Documentation"),
+        ("/llms-full.txt", "Starknet"),
+        ("/.well-known/llms.txt", "# Starknet Documentation"),
+        ("/.well-known/llms-full.txt", "Starknet"),
+        ("/sitemap.xml", "<urlset"),
+        ("/robots.txt", f"Sitemap: {base_url}/sitemap.xml"),
+    ]
+
+    for path, expected_text in checks:
+        check_endpoint(base_url, path, expected_text)
+    check_homepage_headers(base_url)
+
+    print(f"discovery endpoint check passed for {base_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_discovery_endpoints.py
+++ b/scripts/check_discovery_endpoints.py
@@ -107,6 +107,8 @@ def check_endpoint(base_url: str, path: str, expected_text: str) -> None:
 
 def check_homepage_headers(base_url: str) -> None:
     response = fetch(f"{base_url}/", method="HEAD")
+    if response.status in {405, 501}:
+        response = fetch(f"{base_url}/", method="GET")
     assert_status(response)
 
     link_header = ", ".join(response.headers.get("link", []))


### PR DESCRIPTION
## Summary

Add a lightweight live health check for the public `docs.starknet.io` discovery surface used by agents, crawlers, and developer tools.

This complements the existing local `llms.txt` validator. The local validator checks repository format and link integrity; this workflow checks that the deployed docs site still exposes the expected discovery endpoints and headers after build, hosting, CDN, or platform changes.

## What This Prevents

Examples of regressions this should catch:

- `llms.txt` or `llms-full.txt` stops being served after a docs platform or Mintlify config change.
- `.well-known/llms.txt` or `.well-known/llms-full.txt` disappears even though the root files still exist.
- `robots.txt` is regenerated without the docs sitemap reference.
- Homepage discovery headers stop advertising the `llms.txt` and `llms-full.txt` locations.
- A CDN/proxy behavior change breaks `HEAD /` or flattens repeated `Link` headers in a way that affects discovery.

## What This Checks

- `https://docs.starknet.io/llms.txt`
- `https://docs.starknet.io/llms-full.txt`
- `https://docs.starknet.io/.well-known/llms.txt`
- `https://docs.starknet.io/.well-known/llms-full.txt`
- `https://docs.starknet.io/sitemap.xml`
- `https://docs.starknet.io/robots.txt`
- Homepage discovery headers:
  - `Link` with `rel="llms-txt"`
  - `Link` with `rel="llms-full-txt"`
  - `x-llms-txt: /llms.txt`

## Workflow Behavior

- Runs manually via `workflow_dispatch`
- Runs weekly on Monday
- Runs on PRs only when the health-check script or workflow changes
- Does not run on normal docs content edits

The checker includes bounded retries, retryable HTTP status handling, a job timeout, multi-value header support, origin-only `--base-url` validation, and a GET fallback when `HEAD /` is unsupported.

## Validation

Ran locally:

```bash
python3 scripts/validate_llms_txt.py
python3 scripts/check_discovery_endpoints.py
```

Both pass.
