### PR TITLE
docs(readme): add 'Tracked on web3-discover' badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🌟 The Starknet Docs Repository
 
+[![Tracked on web3-discover](https://web3-discover.vercel.app/badge/starknet-provisions-unlock.svg)](https://web3-discover.vercel.app/airdrops/starknet-provisions-unlock)
+
 <div align="center">
 
 [![Built with Mintlify](https://img.shields.io/badge/built%20with-mintlify-00D4AA?style=for-the-badge)](https://mintlify.com)


### PR DESCRIPTION
Hi — this adds a small README badge linking to this project's listing on **[web3-discover](https://web3-discover.vercel.app)**, an honest hand-curated directory of currently-active airdrops and on-chain incentive programs (no paid placements, scam-filtered, risk-flagged).

The listing for this project: https://web3-discover.vercel.app/airdrops/starknet-provisions-unlock

The badge renders as:
> [![Tracked on web3-discover](https://web3-discover.vercel.app/badge/starknet-provisions-unlock.svg)](https://web3-discover.vercel.app/airdrops/starknet-provisions-unlock)

It's a single line near the top of the README and doesn't touch anything else. If you'd rather not host a third-party badge here, no problem — please feel free to close. I won't follow up.

— [@west0nG](https://github.com/west0nG)