### PR TITLE
chore: migrate Starknet docs URLs to new paths

### DIFF
--- a/archive/cairozero/index.rst
+++ b/archive/cairozero/index.rst
@@ -9,7 +9,7 @@ can be used to provide scalability to blockchains.
 StarkNet uses the **Cairo** programming language both for its infrastructure
 and for writing StarkNet contracts.
 If you are looking for StarkNet specific documentation then
-please see `here <https://docs.starknet.io/documentation/>`__.
+please see `here <https://docs.starknet.io/>`__.
 
 Here we provide two tutorials:
 
@@ -30,7 +30,7 @@ for those who want to get a better understanding of those topics.
 If you want to write Cairo programs, independent of StarkNet, start with "Hello, Cairo".
 
 If you are looking for an introduction to StarkNet specifically,
-then you can visit the StarkNet documentation `here <https://docs.starknet.io/documentation/>`__.
+then you can visit the StarkNet documentation `here <https://docs.starknet.io/>`__.
 
 Finally, if you want to understand Cairo's internals from the ground up,
 start with "How Cairo Works" and then follow with "Hello, Cairo".

--- a/learn/cheatsheets/version-notes.mdx
+++ b/learn/cheatsheets/version-notes.mdx
@@ -45,7 +45,7 @@ You can get the latest updates delivered to your inbox by subscribing to the [St
 <Update label="Starknet v0.13.6 (July 8, '25)">
   Starknet v0.13.6 is live on Mainnet.
 
-  This version is a configuration change done to support integration by the [S-Two prover](https://docs.starknet.io/stwo-book/), including:
+  This version is a configuration change done to support integration by the [S-Two prover](https://docs.starknet.io/learn/S-two-book/introduction), including:
 
   - Introducing builtin tracking and temporarily disabling Cairo Native: The [Starknet OS](/learn/protocol/snos) now tracks individual builtins usages, [capping the number of builtins that may fit inside each block](/learn/cheatsheets/chain-info#block_builtin_limits). Since [Cairo Native](https://github.com/lambdaclass/cairo_native) does currently not support this kind of tracking, its usage is temporarily disabled and will be enabled again once this capability is supported.
   - Reducing maximum block size: The amount of L2 gas that a block can contain is [decreased from 5B to 4B L2 gas](/learn/cheatsheets/chain-info#current_limits).
@@ -337,7 +337,7 @@ You can get the latest updates delivered to your inbox by subscribing to the [St
 </Update>
 
 <Update label="Starknet v0.9.0 (June 06, '22)">
-  This version introduces the contract class/instance paradigm into Starknet. See [here](https://docs.starknet.io/documentation/architecture_and_learn/architecture/Contracts/contract-classes/) for more information.
+  This version introduces the contract class/instance paradigm into Starknet. See [here](https://docs.starknet.io/learn/protocol/state#the-class-trie) for more information.
 
   This version contains the following changes:
 


### PR DESCRIPTION
Update documentation links per docs.starknet.io site restructure.