### PR TITLE
docs(privacy): use 'Private' instead of 'Confidential' in overview description

### DIFF
--- a/build/starknet-privacy/overview.mdx
+++ b/build/starknet-privacy/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Confidential transfers on Starknet with compliant privacy—notes, ZK proofs, and efficient discovery
+description: Private transfers on Starknet with compliant privacy—notes, ZK proofs, and efficient discovery
 icon: shield-halved
 ---
 


### PR DESCRIPTION
Changes the word **Confidential** to **Private** in the `description` frontmatter of the Starknet Privacy overview page.

### Before
\`\`\`
description: Confidential transfers on Starknet with compliant privacy—notes, ZK proofs, and efficient discovery
\`\`\`

### After
\`\`\`
description: Private transfers on Starknet with compliant privacy—notes, ZK proofs, and efficient discovery
\`\`\`

File: \`build/starknet-privacy/overview.mdx\` (line 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)