### PR TITLE
docs: add Chainstack Self-Hosted as a Pathfinder deployment option

### DIFF
--- a/secure/quickstart/running-a-node.mdx
+++ b/secure/quickstart/running-a-node.mdx
@@ -291,3 +291,7 @@ To stop the node's execution, run:
 docker stop pathfinder
 ```
 </Note>
+
+## Deploy with Chainstack Self-Hosted
+
+[Chainstack Self-Hosted](https://docs.chainstack.com/docs/self-hosted/introduction) is a web UI and CLI for deploying a Pathfinder node on your own Kubernetes cluster, cloud, or on-premises infrastructure. It includes built-in monitoring, is free to use, and requires no Chainstack account. Built by Chainstack.


### PR DESCRIPTION
Adds Chainstack Self-Hosted to the "Running a node" page — a free web UI and CLI that deploys a Pathfinder node on your own Kubernetes/cloud/on-prem infrastructure, with built-in monitoring and no account required.

Starknet is a supported deployment in Chainstack Self-Hosted (Pathfinder): https://docs.chainstack.com/docs/self-hosted/supported-clients-and-protocols#starknet

Chainstack is already listed as an RPC provider in the developer integrations cheatsheet; this is the distinct self-hosted deployment path. It mirrors the entry on ethereum.org's "Guided setup" section of its run-a-node page.

Disclosure: I work at Chainstack; this is Chainstack's tooling. Happy to adjust wording or placement.
