### PR TITLE
Add STRK20 by Example integration hub to Starknet Privacy docs

### DIFF
--- a/build/starknet-privacy/anonymous-defi.mdx
+++ b/build/starknet-privacy/anonymous-defi.mdx
@@ -50,7 +50,7 @@ The helper is needed because the output amount is only known after the Vesu call
 
 ### Interface sketch (Cairo)
 
-The following excerpt shows the **shape** of an invoke helper for reference. **Most users will interact through existing deployed helpers** (like the Vesu lending helper above), not write their own. Teams building new DeFi integrations can use this as a starting point—a full guide will ship with the SDK:
+The following excerpt shows the **shape** of an invoke helper for reference. **Most users will interact through existing deployed helpers** (like the Vesu lending helper above), not write their own. Teams building new DeFi integrations can use this as a starting point—for working helper integrations (Vesu lending, swaps, escrow), see the [DeFi helper examples in STRK20 by Example](https://strk20-by-example.org/helpers/vesu-lending-helper):
 
 ```cairo
 pub enum LendingOperation { Deposit, Withdraw }

--- a/build/starknet-privacy/overview.mdx
+++ b/build/starknet-privacy/overview.mdx
@@ -15,9 +15,10 @@ and enterprises can understand how Starknet Privacy works.
 - **Live on mainnet:** the privacy pool contract is deployed at
   [`0x0403…812a`](https://voyager.online/contract/0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a).
   The contract source is readable on Voyager.
-- **SDK not yet public:** the TypeScript SDK and proving stack are not open
-  sourced yet. When they ship, operational guides (install, quickstart,
-  end-to-end usage) will be added here.
+- **SDK now open source:** the TypeScript SDK and proving stack are available in the
+  [starknet-privacy repo](https://github.com/starkware-libs/starknet-privacy).
+  For hands-on integration guides (install, quickstart, end-to-end flows), see
+  [STRK20 by Example](https://strk20-by-example.org/).
 
 ## Why Starknet Privacy?
 
@@ -43,6 +44,12 @@ For the latest maintained cross-protocol comparison grid, use [privacygrid.dev](
   </Card>
   <Card title="Protocol deep-dives" icon="book" href="/build/starknet-privacy/architecture">
     Architecture, flows, and cryptography in these docs
+  </Card>
+  <Card title="STRK20 by Example" icon="code" href="https://strk20-by-example.org/">
+    Hands-on integration hub: runnable SDK examples, DeFi helpers, and wallet integration guides
+  </Card>
+  <Card title="SDK source" icon="github" href="https://github.com/starkware-libs/starknet-privacy">
+    TypeScript SDK and proving stack in the starknet-privacy repo
   </Card>
 </CardGroup>
 

--- a/build/starknet-privacy/strk20-by-example.mdx
+++ b/build/starknet-privacy/strk20-by-example.mdx
@@ -1,0 +1,37 @@
+---
+title: "STRK20 by Example"
+description: "Hands-on hub of runnable examples for integrating STRK20 confidential transfers"
+icon: code
+---
+
+These docs explain **how Starknet Privacy works**. When you are ready to build,
+[**STRK20 by Example**](https://strk20-by-example.org/) is the hands-on companion:
+a hub of runnable examples for teams integrating STRK20 into their apps, built on
+the open-source [starknet-privacy SDK](https://github.com/starkware-libs/starknet-privacy).
+
+## What you'll find
+
+<CardGroup cols={2}>
+  <Card title="SDK examples" icon="cube" href="https://strk20-by-example.org/sdk/getting-started">
+    Setup, registration, deposits, transfers, withdrawals, note discovery,
+    proving configuration, and multi-operation batches
+  </Card>
+  <Card title="DeFi helpers" icon="arrows-rotate" href="https://strk20-by-example.org/helpers/privacy-invoke">
+    Privacy Invoke, Vesu lending, swaps, and escrow — working open-note
+    helper integrations
+  </Card>
+  <Card title="Wallet integration" icon="wallet" href="https://strk20-by-example.org/starknet-wallet-api/overview">
+    Starknet Wallet API and starknet.js patterns for privacy-enabled dApps
+  </Card>
+  <Card title="Example app" icon="rocket" href="https://strk20-by-example.org/app/anonymous-airdrop">
+    An end-to-end anonymous airdrop application combining the pieces
+  </Card>
+</CardGroup>
+
+## How it relates to these docs
+
+| You want to... | Go to |
+| --- | --- |
+| Understand the protocol (notes, channels, proofs, compliance) | These docs — start with the [overview](/build/starknet-privacy/overview) |
+| Integrate STRK20 into your app with working code | [STRK20 by Example](https://strk20-by-example.org/) |
+| Read the SDK and proving stack source | [starknet-privacy repo](https://github.com/starkware-libs/starknet-privacy) |

--- a/docs.json
+++ b/docs.json
@@ -1106,7 +1106,8 @@
               {
                 "group": "Getting started",
                 "pages": [
-                  "build/starknet-privacy/overview"
+                  "build/starknet-privacy/overview",
+                  "build/starknet-privacy/strk20-by-example"
                 ]
               },
               {

--- a/learn/cheatsheets/tools.mdx
+++ b/learn/cheatsheets/tools.mdx
@@ -32,6 +32,7 @@ are Starknet's various software development kits (SDKs)
 * [Dojo](https://www.dojoengine.org/) is a developer friendly framework for building provable Games, Autonomous Worlds and other Applications that are natively composable, extensible, permissionless and persistent.
 * [Chipi SDK](https://sdk.chipipay.com/introduction) is an open-source developer toolkit that enables Starknet applications to create non-custodial wallets using any social login (Google, Apple, Telegram, etc.), sponsor transactions via integration with [AVNU's Paymaster](/learn/cheatsheets/integrations#infrastructure), and build with their favourite auth provider with no black boxes.
 * [Cavos](https://aegis.cavos.xyz/) is a wallet infrastructure service that enables instant wallet creation, gasless transactions, multi-provider authentication, and cross-platform SDKs
+* [STRK20 by Example](https://strk20-by-example.org/) is a one-stop hub of runnable examples for integrating STRK20 confidential transfers into apps, covering the [starknet-privacy SDK](https://github.com/starkware-libs/starknet-privacy) (deposits, transfers, withdrawals, note discovery), DeFi helpers, and wallet integration.
 
 ## AI tools
 


### PR DESCRIPTION
## What

The [starknet-privacy repo](https://github.com/starkware-libs/starknet-privacy) (TypeScript SDK + proving stack) is now open source. This PR updates the Starknet Privacy docs accordingly and adds **[STRK20 by Example](https://strk20-by-example.org/)** — a hub of runnable examples for teams integrating STRK20 confidential transfers, built by the Ecosystem Growth team.

## Changes

- **`build/starknet-privacy/overview.mdx`** — replaces the stale *"SDK not yet public"* bullet (the docs promised operational guides would be linked once the SDK ships — it has), and adds *STRK20 by Example* + *SDK source* cards to the Resources grid.
- **`build/starknet-privacy/strk20-by-example.mdx` (new)** — a short landing page under *Getting started* introducing the hub: SDK examples (deposits, transfers, withdrawals, note discovery, proving config, batches), DeFi helpers (Privacy Invoke, Vesu lending, swaps, escrow), wallet integration, and an end-to-end example app.
- **`docs.json`** — registers the new page in the *Starknet Privacy → Getting started* group.
- **`learn/cheatsheets/tools.mdx`** — adds STRK20 by Example under *dApp tools*.
- **`build/starknet-privacy/anonymous-defi.mdx`** — the invoke-helper section said *"a full guide will ship with the SDK"*; it now points to the working helper examples.

## Verification

- All external links checked (200): strk20-by-example.org pages, the starknet-privacy repo, and the SDK README.
- Rendered locally with `mint dev` — all four changed pages render correctly, new page appears in the sidebar under Getting started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)