### PR TITLE
docs(privacy): use "private transfers" instead of "confidential transfers"

### DIFF
--- a/build/starknet-privacy/overview.mdx
+++ b/build/starknet-privacy/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Confidential transfers on Starknet with compliant privacy—notes, ZK proofs, and efficient discovery
+description: Private transfers on Starknet with compliant privacy—notes, ZK proofs, and efficient discovery
 icon: shield-halved
 ---
 
@@ -22,7 +22,7 @@ and enterprises can understand how Starknet Privacy works.
 
 ## Why Starknet Privacy?
 
-If you care about confidential transfers, you have probably seen mixers (fixed amounts, one-time use) or privacy chains that require a separate ecosystem. Starknet Privacy takes a different path:
+If you care about private transfers, you have probably seen mixers (fixed amounts, one-time use) or privacy chains that require a separate ecosystem. Starknet Privacy takes a different path:
 
 - **Stay on Starknet** — no new chain; access existing Starknet DeFi and accounts.
 - **Arbitrary amounts, reusable notes** — no fixed denominations.

--- a/build/starknet-privacy/strk20-by-example.mdx
+++ b/build/starknet-privacy/strk20-by-example.mdx
@@ -1,6 +1,6 @@
 ---
 title: "STRK20 by Example"
-description: "Hands-on hub of runnable examples for integrating STRK20 confidential transfers"
+description: "Hands-on hub of runnable examples for integrating STRK20 private transfers"
 icon: code
 ---
 

--- a/learn/cheatsheets/tools.mdx
+++ b/learn/cheatsheets/tools.mdx
@@ -32,7 +32,7 @@ are Starknet's various software development kits (SDKs)
 * [Dojo](https://www.dojoengine.org/) is a developer friendly framework for building provable Games, Autonomous Worlds and other Applications that are natively composable, extensible, permissionless and persistent.
 * [Chipi SDK](https://sdk.chipipay.com/introduction) is an open-source developer toolkit that enables Starknet applications to create non-custodial wallets using any social login (Google, Apple, Telegram, etc.), sponsor transactions via integration with [AVNU's Paymaster](/learn/cheatsheets/integrations#infrastructure), and build with their favourite auth provider with no black boxes.
 * [Cavos](https://aegis.cavos.xyz/) is a wallet infrastructure service that enables instant wallet creation, gasless transactions, multi-provider authentication, and cross-platform SDKs
-* [STRK20 by Example](https://strk20-by-example.org/) is a one-stop hub of runnable examples for integrating STRK20 confidential transfers into apps, covering the [starknet-privacy SDK](https://github.com/starkware-libs/starknet-privacy) (deposits, transfers, withdrawals, note discovery), DeFi helpers, and wallet integration.
+* [STRK20 by Example](https://strk20-by-example.org/) is a one-stop hub of runnable examples for integrating STRK20 private transfers into apps, covering the [starknet-privacy SDK](https://github.com/starkware-libs/starknet-privacy) (deposits, transfers, withdrawals, note discovery), DeFi helpers, and wallet integration.
 
 ## AI tools
 


### PR DESCRIPTION
## What
Standardizes wording in the Starknet Privacy docs: **"confidential transfer(s)" → "private transfer(s)"**.

## Why
The Starknet Privacy **Overview** page mixed both terms — the page subtitle said *"Confidential transfers on Starknet…"* while the body describes a *"protocol for private asset transfers."* These are different concepts, so the mismatch was confusing.

## Changes
- `build/starknet-privacy/overview.mdx` — page subtitle + "Why Starknet Privacy?" intro
- `build/starknet-privacy/strk20-by-example.mdx` — page subtitle
- `learn/cheatsheets/tools.mdx` — STRK20 by Example entry

## Deliberately unchanged
- **"confidential note(s)"** — a distinct technical term (contrasted with "open notes")
- **Starkzap "Confidential Transfers"** (Tongo protocol) — a separate product where the term is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)