### PR TITLE
docs(learn): add Security Council page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -945,6 +945,7 @@
                   "learn/protocol/data-availability",
                   "learn/protocol/fees",
                   "learn/protocol/messaging",
+                  "learn/protocol/security-council",
                   "learn/protocol/staking",
                   "learn/protocol/state",
                   "learn/protocol/strk",

--- a/learn/protocol/security-council.mdx
+++ b/learn/protocol/security-council.mdx
@@ -27,6 +27,6 @@ The Council's 12 seats are held by individuals affiliated with the following org
 
 ## Additional resources
 
-- [SNIP 25: Starknet Security Council V1.0](https://community.starknet.io/t/snip25-starknet-security-council-v1-0/115060) on the Starknet community forum
-- [SNIP 25](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-25.md) on GitHub (canonical text)
+- [SNIP 25](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-25.md) on GitHub
+- [SNIP 25 discussion on the Starknet community forum](https://community.starknet.io/t/snip25-starknet-security-council-v1-0/115060)
 - [Starknet Security Council's new framework for network security](https://www.starknet.io/blog/starknets-security-council/) on the Starknet blog

--- a/learn/protocol/security-council.mdx
+++ b/learn/protocol/security-council.mdx
@@ -1,0 +1,32 @@
+---
+title: "Security Council"
+---
+
+## Overview
+
+The Starknet Security Council (SC) is a 12-member body that holds administrative control over Starknet's core contracts on both Starknet and Ethereum. Its purpose is to decentralize the ability to upgrade, pause, and unpause those contracts, so that no single organization can unilaterally change the protocol, while still allowing the network to respond to a live security incident within minutes.
+
+## Member entities
+
+The Council's 12 seats are held by individuals affiliated with the following organizations:
+
+| Organization |
+| --- |
+| StarkWare |
+| Nethermind |
+| Zellic |
+| Hypernative |
+| Pragma |
+| AVNU |
+| Cartridge |
+| Ready |
+| Karnot |
+| Space Duck |
+| Flying Muffins |
+| Protolabs |
+
+## Additional resources
+
+- [SNIP 25: Starknet Security Council V1.0](https://community.starknet.io/t/snip25-starknet-security-council-v1-0/115060) on the Starknet community forum
+- [SNIP 25](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-25.md) on GitHub (canonical text)
+- [Starknet Security Council's new framework for network security](https://www.starknet.io/blog/starknets-security-council/) on the Starknet blog

--- a/llms.txt
+++ b/llms.txt
@@ -41,6 +41,7 @@ Use this file for high-signal discovery. Use `llms-full.txt` for exhaustive cont
 - [Blocks](https://docs.starknet.io/learn/protocol/blocks.md): Block production and structure.
 - [State](https://docs.starknet.io/learn/protocol/state.md): State model and transitions.
 - [Staking](https://docs.starknet.io/learn/protocol/staking.md): Staking mechanics and validator economics.
+- [Security Council](https://docs.starknet.io/learn/protocol/security-council.md): The 12-member body holding administrative control over Starknet's core contracts.
 
 ## Security and Operations
 


### PR DESCRIPTION
## What

Adds a **Security Council** page under **Learn → Protocol → Concepts**, covering what the Council is and which organizations hold its 12 seats.

Three files change:
- `learn/protocol/security-council.mdx` — the new page
- `docs.json` — nav entry, inserted alphabetically in the Concepts group (between `messaging` and `staking`)
- `llms.txt` — matching entry under Protocol Fundamentals, since every other Concepts page is listed there



🤖 Generated with [Claude Code](https://claude.com/claude-code)
