### PR TITLE
docs(learn): add node101 RPC provider

### DIFF
--- a/learn/cheatsheets/integrations.mdx
+++ b/learn/cheatsheets/integrations.mdx
@@ -21,6 +21,7 @@ This page is continuously updated. If a project you are using is missing, please
 [GetBlock](https://getblock.io/nodes/strk/),
 [Infura](https://www.infura.io/networks/ethereum/starknet),
 [Lava](https://www.lavanet.xyz/),
+[node101](https://node101.io/en/rpc/starknet),
 [NOWNodes](https://nownodes.io/starknet),
 [OMNIA](https://omniatech.io/),
 [OnFinality](https://onfinality.io/networks/starknet),


### PR DESCRIPTION
## Summary

- adds node101 to the Starknet RPC providers list on the Developer integrations page
- links to the dedicated node101 Starknet RPC service page

## Validation

- `python3 scripts/validate_llms_txt.py`

Disclosure: I am affiliated with node101.