### PR TITLE
docs: update stale Cavos listing on developer tools page

### DIFF
--- a/learn/cheatsheets/tools.mdx
+++ b/learn/cheatsheets/tools.mdx
@@ -31,7 +31,7 @@ are Starknet's various software development kits (SDKs)
 * [Dynamic SDK](https://go.dynamic.xyz/4eFmNMI) combines authentication, smart wallets, and secure key management into one flexible SDK that enables multi-chain coverage across chains and third-party wallets.
 * [Dojo](https://www.dojoengine.org/) is a developer friendly framework for building provable Games, Autonomous Worlds and other Applications that are natively composable, extensible, permissionless and persistent.
 * [Chipi SDK](https://sdk.chipipay.com/introduction) is an open-source developer toolkit that enables Starknet applications to create non-custodial wallets using any social login (Google, Apple, Telegram, etc.), sponsor transactions via integration with [AVNU's Paymaster](/learn/cheatsheets/integrations#infrastructure), and build with their favourite auth provider with no black boxes.
-* [Cavos](https://aegis.cavos.xyz/) is a wallet infrastructure service that enables instant wallet creation, gasless transactions, multi-provider authentication, and cross-platform SDKs
+* [Cavos](https://cavos.xyz) is a device-native embedded self-custodial wallet SDK. Users sign in with Google or Apple; the key stays on the device and Cavos cannot move funds. Starknet, Solana, and Stellar.
 * [STRK20 by Example](https://strk20-by-example.org/) is a one-stop hub of runnable examples for integrating STRK20 private transfers into apps, covering the [starknet-privacy SDK](https://github.com/starkware-libs/starknet-privacy) (deposits, transfers, withdrawals, note discovery), DeFi helpers, and wallet integration.
 
 ## AI tools


### PR DESCRIPTION
## Summary

The Cavos entry on the developer tools cheatsheet still points at the old Aegis product URL and describes the previous wallet-infrastructure positioning (including an overclaim of “gasless transactions”).

This PR updates only that listing to the current Cavos site and an accurate one-line description.

**Before**
```
* [Cavos](https://aegis.cavos.xyz/) is a wallet infrastructure service that enables instant wallet creation, gasless transactions, multi-provider authentication, and cross-platform SDKs
```

**After**
```
* [Cavos](https://cavos.xyz) is a device-native embedded self-custodial wallet SDK. Users sign in with Google or Apple; the key stays on the device and Cavos cannot move funds. Starknet, Solana, and Stellar.
```

- Primary link: https://cavos.xyz (docs: https://docs.cavos.xyz)
- Dropped “gasless” — gas sponsorship is pass-through, not a Cavos-provided guarantee
- No other listings changed

## Test plan

- [ ] Confirm https://docs.starknet.io/learn/cheatsheets/tools Cavos bullet links to https://cavos.xyz
- [ ] Confirm neighboring dApp-tool entries are unchanged